### PR TITLE
Fix links to repos now in flatsurf org

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,7 +61,7 @@ the released version of sage-flatsurf can be installed by running the following 
 
 To install the development version of sage-flatsurf, run instead::
 
-    $ sage --pip install git+https://github.com/videlec/sage-flatsurf [--user] [--upgrade]
+    $ sage --pip install git+https://github.com/flatsurf/sage-flatsurf [--user] [--upgrade]
 
 The options ``--user`` and ``--upgrade`` are optional; ``--user`` is to
 perform the installation in your user home instead of in the Sage sources;
@@ -143,8 +143,8 @@ Acknowledgements
   Horizon 2020 European Research Infrastructures project #676541.
 
 .. _SageMath: https://www.sagemath.org
-.. _surface_dynamics: https://gitlab.com/videlec/surface_dynamics
+.. _surface_dynamics: https://github.com/flatsurf/surface_dynamics
 .. _veerer: https://gitlab.com/videlec/veerer/
 .. _libflatsurf: https://github.com/flatsurf/flatsurf
-.. _e-antic: https://github.com/videlec/e-antic
+.. _e-antic: https://github.com/flatsurf/e-antic
 .. _exact-real: https://github.com/flatsurf/exact-real

--- a/README.rst
+++ b/README.rst
@@ -39,17 +39,11 @@ Links
 
 * Development website: https://github.com/flatsurf/sage-flatsurf/
 
-Installing the dependency
--------------------------
+Dependencies
+------------
 
-sage-flatsurf depends on the `surface_dynamics`_ package, which is
-distributed on PyPI and can be installed with the following command::
-
-    $ sage --pip install surface_dynamics [--user] [--upgrade]
-
-The options ``--user`` and ``--upgrade`` are optional; ``--user`` is to
-perform the installation in your user home instead of in the Sage sources;
-``--upgrade`` is to upgrade the package in case it is already installed.
+- `surface_dynamics`_
+- (optional) `libflatsurf`_
 
 Installing the package
 ----------------------
@@ -104,9 +98,6 @@ files in the module just do::
 
     $ sage -t --force-lib flatsurf
 
-Tests on the master branch are automatically run through
-`Travis-CI <https://travis-ci.org/github/flatsurf/sage-flatsurf>`_.
-
 Related projects
 ----------------
 
@@ -121,11 +112,15 @@ There are several related projects
 * `libflatsurf`_: (C++ library with Python interface) computing GL(2,R)-orbit
   closures of translation surfaces
 
-Primary Contributors
---------------------
+* `curver`_ (Python module): computation in the curve complex and the mapping
+  class group
+
+Contributors
+------------
 
 * Vincent Delecroix (Bordeaux)
 * Pat Hooper (City College of New York and CUNY Graduate Center)
+* Julian Rüth
 
 We welcome others to contribute.
 
@@ -148,3 +143,4 @@ Acknowledgements
 .. _libflatsurf: https://github.com/flatsurf/flatsurf
 .. _e-antic: https://github.com/flatsurf/e-antic
 .. _exact-real: https://github.com/flatsurf/exact-real
+.. _curver: https://github.com/MarkCBell/curver


### PR DESCRIPTION
The repos for some dependencies have moved to the
flatsurf org. We update their urls in the README.

The part about continuous integration also needs
updating after the move away from Travis-CI.
Can someone take care of that?