### PR TITLE
Ignore macOS .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ doc/_build/*
 dist/
 MANIFEST
 /rever
+.DS_Store


### PR DESCRIPTION
To make git status quieter for anyone developing under macOS
and browsing files using the macOS Finder.