### PR TITLE
Speed up action of a matrix on a polygon

### DIFF
--- a/doc/news/act.rst
+++ b/doc/news/act.rst
@@ -1,0 +1,4 @@
+**Performance:**
+
+* Improved acting with a matrix on a polygon by not checking convexity of the result.
+

--- a/flatsurf/geometry/polygon.py
+++ b/flatsurf/geometry/polygon.py
@@ -585,13 +585,13 @@ class MatrixActionOnPolygons(Action):
         """
         det = g.det()
         if det > 0:
-            return x.parent()(vertices=[g*v for v in x.vertices()])
+            return x.parent()(vertices=[g*v for v in x.vertices()], check=False)
         if det < 0:
             # Note that in this case we reverse the order
             vertices = [g*x.vertex(0)]
             for i in range(x.num_edges() - 1, 0, -1):
                 vertices.append(g * x.vertex(i))
-            return x.parent()(vertices=vertices)
+            return x.parent()(vertices=vertices, check=False)
         raise ValueError("Can not act on a polygon with matrix with zero determinant")
 
 class PolygonPosition:


### PR DESCRIPTION
In this trivial example, the runtime goes from 122µs to 66μs.
```py
sage: from flatsurf import polygons
sage: p = polygons(vertices = [(1,0),(0,1),(-1,-1)])
sage: r = matrix(ZZ,[[0,1], [1,0]])
sage: %timeit r*p
```