### PR TITLE
make tangent vector and segments hashable

### DIFF
--- a/flatsurf/geometry/gl2r_orbit_closure.py
+++ b/flatsurf/geometry/gl2r_orbit_closure.py
@@ -133,8 +133,14 @@ class GL2ROrbitClosure:
 
     We now illustrate the projection::
 
-        sage: V = O.proj._row_ambient_module() # optional: pyflatsurf
-        sage: H = O.proj._column_ambient_module() # optional: pyflatsurf
+        sage: try: # optional: pyflatsurf
+        ....:     V = O.proj.row_ambient_module()
+        ....: except AttributeError:
+        ....:     V = O.proj._row_ambient_module()
+        sage: try: # optional: pyflatsurf
+        ....:     H = O.proj.column_ambient_module()
+        ....: except AttributeError:
+        ....:     H = O.proj._column_ambient_module()
         sage: assert O.proj.rank() == H.dimension() # optional: pyflatsurf
         sage: for b in O.boundaries(): # optional: pyflatsurf
         ....:    assert (O.proj * b).is_zero()

--- a/flatsurf/geometry/straight_line_trajectory.py
+++ b/flatsurf/geometry/straight_line_trajectory.py
@@ -435,14 +435,11 @@ class AbstractStraightLineTrajectory:
 
             sage: for p, (segs1, segs2) in traj1.intersections(traj2, include_segments=True):
             ....:     print(p)
-            ....:     print(segs1)
-            ....:     print(segs2)
+            ....:     print(len(segs1), len(segs2))
             Surface point with 2 coordinate representations
-            {Segment in polygon 0 starting at (1/2, 0) and ending at (1, 1/2), Segment in polygon 0 starting at (0, 1/2) and ending at (1/2, 1)}
-            {Segment in polygon 0 starting at (1, 1/2) and ending at (1/2, 1), Segment in polygon 0 starting at (1/2, 0) and ending at (0, 1/2)}
+            2 2
             Surface point with 2 coordinate representations
-            {Segment in polygon 0 starting at (1/2, 0) and ending at (1, 1/2), Segment in polygon 0 starting at (0, 1/2) and ending at (1/2, 1)}
-            {Segment in polygon 0 starting at (1, 1/2) and ending at (1/2, 1), Segment in polygon 0 starting at (1/2, 0) and ending at (0, 1/2)}
+            2 2
         """
         # Partition the segments making up the trajectories by label.
         if isinstance(traj,SaddleConnection):

--- a/flatsurf/geometry/straight_line_trajectory.py
+++ b/flatsurf/geometry/straight_line_trajectory.py
@@ -396,17 +396,17 @@ class AbstractStraightLineTrajectory:
     def terminal_tangent_vector(self):
         return self.segment(-1).end()
 
-    def intersects(self, traj, count_singularities = False):
+    def intersects(self, traj, count_singularities=False):
         r"""
         Return true if this trajectory intersects the other trajectory.
         """
         try:
-            next(self.intersections(traj, count_singularities = count_singularities))
+            next(self.intersections(traj, count_singularities=count_singularities))
         except StopIteration:
             return False
         return True
 
-    def intersections(self, traj, count_singularities = False, include_segments = False):
+    def intersections(self, traj, count_singularities=False, include_segments=False):
         r"""
         Return the set of SurfacePoints representing the intersections
         of this trajectory with the provided trajectory or SaddleConnection.
@@ -420,8 +420,8 @@ class AbstractStraightLineTrajectory:
 
         EXAMPLES::
 
-            sage: from flatsurf import *
-            sage: s=translation_surfaces.square_torus()
+            sage: from flatsurf import translation_surfaces
+            sage: s = translation_surfaces.square_torus()
             sage: traj1 = s.tangent_vector(0,(1/2,0),(1,1)).straight_line_trajectory()
             sage: traj1.flow(3)
             sage: traj1.is_closed()
@@ -432,6 +432,17 @@ class AbstractStraightLineTrajectory:
             True
             sage: sum(1 for _ in traj1.intersections(traj2))
             2
+
+            sage: for p, (segs1, segs2) in traj1.intersections(traj2, include_segments=True):
+            ....:     print(p)
+            ....:     print(segs1)
+            ....:     print(segs2)
+            Surface point with 2 coordinate representations
+            {Segment in polygon 0 starting at (1/2, 0) and ending at (1, 1/2), Segment in polygon 0 starting at (0, 1/2) and ending at (1/2, 1)}
+            {Segment in polygon 0 starting at (1, 1/2) and ending at (1/2, 1), Segment in polygon 0 starting at (1/2, 0) and ending at (0, 1/2)}
+            Surface point with 2 coordinate representations
+            {Segment in polygon 0 starting at (1/2, 0) and ending at (1, 1/2), Segment in polygon 0 starting at (0, 1/2) and ending at (1/2, 1)}
+            {Segment in polygon 0 starting at (1, 1/2) and ending at (1/2, 1), Segment in polygon 0 starting at (1/2, 0) and ending at (0, 1/2)}
         """
         # Partition the segments making up the trajectories by label.
         if isinstance(traj,SaddleConnection):
@@ -469,15 +480,14 @@ class AbstractStraightLineTrajectory:
                                 if new_point not in intersection_points:
                                     intersection_points.add(new_point)
                                     if include_segments:
-                                        segments[new_point]=({seg1},{seg2})
+                                        segments[new_point] = ({seg1}, {seg2})
                                     else:
                                         yield new_point
                                 elif include_segments:
-                                    segments[new_point][0].append(seg1)
-                                    segments[new_point][1].append(seg2)
+                                    segments[new_point][0].add(seg1)
+                                    segments[new_point][1].add(seg2)
         if include_segments:
-            for x in iteritems(segments):
-                yield x
+            yield from segments.items()
 
 
 

--- a/flatsurf/geometry/straight_line_trajectory.py
+++ b/flatsurf/geometry/straight_line_trajectory.py
@@ -81,6 +81,18 @@ class SegmentInPolygon:
             self._end = start.forward_to_polygon_boundary()
             self._start = self._end.forward_to_polygon_boundary()
 
+    def __hash__(self):
+        r"""
+        TESTS::
+
+            sage: from flatsurf import similarity_surfaces
+            sage: from flatsurf.geometry.straight_line_trajectory import SegmentInPolygon
+            sage: s = similarity_surfaces.example()
+            sage: v = s.tangent_vector(0, (1/3,-1/4), (0,1))
+            sage: h = hash(SegmentInPolygon(v))
+        """
+        return hash((self._start, self._end))
+
     def __eq__(self, other):
         return type(self) is type(other) and \
                self._start == other._start and \

--- a/flatsurf/geometry/tangent_bundle.py
+++ b/flatsurf/geometry/tangent_bundle.py
@@ -113,6 +113,9 @@ class SimilaritySurfaceTangentVector:
         else:
             raise ValueError("Provided point lies outside the indexed polygon")
 
+        self._point.set_immutable()
+        self._vector.set_immutable()
+
     def __repr__(self):
         return "SimilaritySurfaceTangentVector in polygon "+repr(self._polygon_label)+\
             " based at "+repr(self._point)+" with vector "+repr(self._vector)
@@ -129,7 +132,16 @@ class SimilaritySurfaceTangentVector:
         return not self.__eq__(other)
 
     def __hash__(self):
-        return hash(tuple(sorted(self.__dict__.items())))
+        r"""
+        TESTS::
+
+            sage: from flatsurf import translation_surfaces
+            sage: s = translation_surfaces.square_torus()
+            sage: for y in [0,1]:
+            ....:     for d in [1,-1]:
+            ....:         h = hash(s.tangent_vector(0, (1/2, y), (d, 0)))
+        """
+        return hash((self._bundle, self._polygon_label, self._point, self._vector))
 
     def surface(self):
         r"""Return the underlying surface."""


### PR DESCRIPTION
Tangent vectors and segments were not hashable and this breaks saddle connection intersections when used with the option `include_segments`.