### PR TITLE
Converter

### DIFF
--- a/doc/news/converter.rst
+++ b/doc/news/converter.rst
@@ -1,0 +1,4 @@
+**Added:**
+
+* introduce FlatsurfConverter to deal with conversion between sage-flatsurf
+  and pyflatsurf/libflatsurf

--- a/flatsurf/geometry/gl2r_orbit_closure.py
+++ b/flatsurf/geometry/gl2r_orbit_closure.py
@@ -667,46 +667,16 @@ class GL2ROrbitClosure:
         return B
 
     def decomposition(self, v, limit=-1):
-        v = self.V2(v)
-
-        from flatsurf.features import pyflatsurf_feature
-        pyflatsurf_feature.require()
-        import pyflatsurf
-
-        decomposition = pyflatsurf.flatsurf.makeFlowDecomposition(self._surface, v.vector)
-
-        u = self.V2._isomorphic_vector_space(v)
-        if limit != 0:
-            decomposition.decompose(int(limit))
-        return decomposition
+        return self._converter.flow_decomposition(v, limit)
 
     def decompositions(self, bound, limit=-1, bfs=False):
-        limit = int(limit)
-
-        connections = self._surface.connections().bound(int(bound))
-        if bfs:
-            connections = connections.byLength()
-
-        slopes = None
-
-        from flatsurf.features import cppyy_feature
-        cppyy_feature.require()
-        import cppyy
-
-        for connection in connections:
-            direction = connection.vector()
-            if slopes is None:
-                slopes = cppyy.gbl.std.set[type(direction), type(direction).CompareSlope]()
-            if slopes.find(direction) != slopes.end():
-                continue
-            slopes.insert(direction)
-            yield self.decomposition(direction, limit)
+        return self._converter.flow_decompositions(bound, limit, bfs)
 
     def decompositions_depth_first(self, bound, limit=-1):
-        return self.decompositions(bound, bfs=False, limit=limit)
+        return self._converter.flow_decompositions_depth_first(bound, limit)
 
     def decompositions_breadth_first(self, bound, limit=-1):
-        return self.decompositions(bound, bfs=True, limit=limit)
+        return self._convert.flow_decompositions_breadth_first(self, bound, limit)
 
     def is_teichmueller_curve(self, bound, limit=-1):
         r"""

--- a/flatsurf/geometry/gl2r_orbit_closure.py
+++ b/flatsurf/geometry/gl2r_orbit_closure.py
@@ -151,20 +151,18 @@ class GL2ROrbitClosure:
         from flatsurf.geometry.translation_surface import TranslationSurface
         if isinstance(surface, TranslationSurface):
             base_ring = surface.base_ring()
-            from flatsurf.geometry.pyflatsurf_conversion import to_pyflatsurf
-            self._surface = to_pyflatsurf(surface)
+            from .pyflatsurf_conversion import FlatsurfConverter
+            self._converter = FlatsurfConverter(surface)
+            self._surface = self._converter.pyflatsurf_surface()
+            self.V2 = self._converter._V2
         else:
             from flatsurf.geometry.pyflatsurf_conversion import sage_ring
             base_ring = sage_ring(surface)
             self._surface = surface
-
-        # A model of the vector space R² in libflatsurf, e.g., to represent the
-        # vector associated to a saddle connection.
-        from flatsurf.features import pyflatsurf_feature
-        pyflatsurf_feature.require()
-        import pyflatsurf.vector
-
-        self.V2 = pyflatsurf.vector.Vectors(base_ring)
+            from flatsurf.features import pyflatsurf_feature
+            pyflatsurf_feature.require()
+            import pyflatsurf.vector
+            self.V2 = pyflatsurf.vector.Vectors(base_ring)
 
         # We construct a spanning set of edges, that is a subset of the
         # edges that form a basis of H_1(S, Sigma; Z)

--- a/flatsurf/geometry/gl2r_orbit_closure.py
+++ b/flatsurf/geometry/gl2r_orbit_closure.py
@@ -31,7 +31,7 @@ is set::
     sage: S = translation_surfaces.mcmullen_genus2_prototype(4,2,1,1,1/4)
     sage: l = S.base_ring().gen()
     sage: O = GL2ROrbitClosure(S) # optional: pyflatsurf
-    sage: dec = O.decomposition((8*l - 25, 16), 10) # optional: pyflatsurf
+    sage: dec = O.decomposition((8*l - 25, 16), 5) # optional: pyflatsurf
     sage: dec.undeterminedComponents() # optional: pyflatsurf
     [Component with perimeter [...]]
 
@@ -109,13 +109,13 @@ class GL2ROrbitClosure:
         sage: T = E(R(1), R.random_element(1/4))  # optional: exactreal
         sage: S = similarity_surfaces.billiard(T)  # optional: exactreal
         sage: S = S.minimal_cover(cover_type="translation")  # optional: exactreal
-        sage: O = GL2ROrbitClosure(S); O  # optional: pyflatsurf
+        sage: O = GL2ROrbitClosure(S); O  # optional: pyflatsurf exactreal
         GL(2,R)-orbit closure of dimension at least 4 in H_7(4^3, 0) (ambient dimension 17)
         sage: bound = E.billiard_unfolding_stratum('half-translation', marked_points=True).dimension()
-        sage: for decomposition in O.decompositions(1):  # long time, optional: pyflatsurf
+        sage: for decomposition in O.decompositions(1):  # long time, optional: pyflatsurf exactreal
         ....:     O.update_tangent_space_from_flow_decomposition(decomposition)
         ....:     if O.dimension() == bound: break
-        sage: O  # long time, optional: pyflatsurf
+        sage: O  # long time, optional: pyflatsurf exactreal
         GL(2,R)-orbit closure of dimension at least 8 in H_7(4^3, 0) (ambient dimension 17)
 
     TESTS::
@@ -282,15 +282,15 @@ class GL2ROrbitClosure:
             sage: T = E(R(1), R.random_element(1/4))  # optional: exactreal
             sage: S = similarity_surfaces.billiard(T)  # optional: exactreal
             sage: S = S.minimal_cover(cover_type="translation")  # optional: exactreal
-            sage: O = GL2ROrbitClosure(S); O  # optional: pyflatsurf
+            sage: O = GL2ROrbitClosure(S); O  # optional: exactreal pyflatsurf
             GL(2,R)-orbit closure of dimension at least 4 in H_7(4^3, 0) (ambient dimension 17)
-            sage: O.field_of_definition() # optional: pyflatsurf
+            sage: O.field_of_definition() # optional: exactreal pyflatsurf
             Number Field in c0 with defining polynomial x^2 - 2 with c0 = 1.414213562373095?
             sage: bound = E.billiard_unfolding_stratum('half-translation', marked_points=True).dimension()
-            sage: for decomposition in O.decompositions(1):  # long time, optional: pyflatsurf
+            sage: for decomposition in O.decompositions(1):  # long time, optional: exactreal pyflatsurf
             ....:     if O.dimension() == bound: break
             ....:     O.update_tangent_space_from_flow_decomposition(decomposition)
-            sage: O.field_of_definition()  # long time, optional: pyflatsurf
+            sage: O.field_of_definition()  # long time, optional: exactreal pyflatsurf
             Rational Field
 
             sage: E = EquiangularPolygons(1, 3, 5)
@@ -373,8 +373,8 @@ class GL2ROrbitClosure:
             sage: span([v0, v1])  # optional: pyflatsurf
             Vector space of degree 9 and dimension 2 over Real Embedded Number Field in l with defining polynomial x^2 - x - 8 with l = 3.372281323269015?
             Basis matrix:
-            [                         1                          0                         -1   (1/4*l-1/4 ~ 0.59307033) (-1/4*l+1/4 ~ -0.59307033)                          0 (-1/4*l+1/4 ~ -0.59307033)                          0 (-1/4*l+1/4 ~ -0.59307033)]
-            [                         0                          1                         -1    (1/8*l+7/8 ~ 1.2965352) (-1/8*l+1/8 ~ -0.29653517)                         -1 (3/8*l-11/8 ~ -0.11039450) (-1/2*l+3/2 ~ -0.18614066) (-1/8*l+1/8 ~ -0.29653517)]
+            [                         1                          0                         -1   (1/2*l-3/2 ~ 0.18614066)   (1/8*l-1/8 ~ 0.29653517)                          1    (5/8*l-5/8 ~ 1.4826758)  (5/8*l-13/8 ~ 0.48267583)  (-1/8*l-7/8 ~ -1.2965352)]
+            [                         0                          1                          0                          0   (1/4*l-1/4 ~ 0.59307033)                          1   (1/4*l-1/4 ~ 0.59307033)   (1/4*l-1/4 ~ 0.59307033) (-1/4*l+1/4 ~ -0.59307033)]
 
         This can be used to deform the surface::
 
@@ -675,7 +675,7 @@ class GL2ROrbitClosure:
         return self._converter.flow_decompositions_depth_first(bound, limit)
 
     def decompositions_breadth_first(self, bound, limit=-1):
-        return self._convert.flow_decompositions_breadth_first(self, bound, limit)
+        return self._convert.flow_decompositions_breadth_first(bound, limit)
 
     def is_teichmueller_curve(self, bound, limit=-1):
         r"""
@@ -755,9 +755,9 @@ class GL2ROrbitClosure:
             sage: c0, c1 = dec.components() # optional: pyflatsurf
             sage: kz = O.flow_decomposition_kontsevich_zorich_cocycle(dec) # optional: pyflatsurf
             sage: O.cylinder_circumference(c0, *kz) # optional: pyflatsurf
-            (1, 0, 0, -1)
+            (1, 0, -1, 0)
             sage: O.cylinder_circumference(c1, *kz) # optional: pyflatsurf
-            (0, 0, -1, 0)
+            (0, -1, 0, 0)
         """
         if component.cylinder() != True:
             raise ValueError
@@ -969,22 +969,22 @@ class GL2ROrbitClosure:
             sage: for dec in O.decompositions_depth_first(3):  # optional: pyflatsurf
             ....:     kz = O.flow_decomposition_kontsevich_zorich_cocycle(dec) # optional: pyflatsurf
             ....:     print(kz[0])
-            [ 0  1]
-            [-1 -1]
-            [ 0  1]
-            [-1 -2]
-            [-1 -1]
-            [ 1  0]
-            [-1 -1]
-            [ 2  1]
-            [1 0]
-            [0 1]
+            [ 0 -1]
+            [-1  1]
+            [ 0 -1]
+            [-1  2]
+            [-1  1]
             [ 1  0]
             [-1  1]
-            [ 1 -1]
-            [-1  2]
-            [ 1  0]
+            [ 2 -1]
             [-2  1]
+            [ 3 -1]
+            [-1  1]
+            [ 3 -2]
+            [-1  0]
+            [ 0  1]
+            [-1  0]
+            [ 1  1]
         """
         sc_pos = []   # list of positive boundary saddle connections
                       # (store only one orientation for each)

--- a/flatsurf/geometry/gl2r_orbit_closure.py
+++ b/flatsurf/geometry/gl2r_orbit_closure.py
@@ -150,13 +150,13 @@ class GL2ROrbitClosure:
     def __init__(self, surface):
         from flatsurf.geometry.translation_surface import TranslationSurface
         if isinstance(surface, TranslationSurface):
-            self._converter = surface.pyflatsurf_converter()
+            self._converter = surface._pyflatsurf
         else:
-            from .pyflatsurf_conversion import from_pyflatsurf
-            self._converter = from_pyflatsurf(surface).pyflatsurf_converter()
+            from .pyflatsurf_conversion import FlatsurfConverter
+            self._converter = FlatsurfConverter.from_pyflatsurf(surface)
 
-        self._surface = self._converter.pyflatsurf_surface()
-        self.V2 = self._converter._V2
+        self._surface = self._converter.codomain()
+        self.V2 = self._converter.vector_space()
 
         # We construct a spanning set of edges, that is a subset of the
         # edges that form a basis of H_1(S, Sigma; Z)

--- a/flatsurf/geometry/gl2r_orbit_closure.py
+++ b/flatsurf/geometry/gl2r_orbit_closure.py
@@ -150,18 +150,13 @@ class GL2ROrbitClosure:
     def __init__(self, surface):
         from flatsurf.geometry.translation_surface import TranslationSurface
         if isinstance(surface, TranslationSurface):
-            base_ring = surface.base_ring()
             self._converter = surface.pyflatsurf_converter()
-            self._surface = self._converter.pyflatsurf_surface()
-            self.V2 = self._converter._V2
         else:
-            from flatsurf.geometry.pyflatsurf_conversion import sage_ring
-            base_ring = sage_ring(surface)
-            self._surface = surface
-            from flatsurf.features import pyflatsurf_feature
-            pyflatsurf_feature.require()
-            import pyflatsurf.vector
-            self.V2 = pyflatsurf.vector.Vectors(base_ring)
+            from .pyflatsurf_conversion import from_pyflatsurf
+            self._converter = from_pyflatsurf(surface).pyflatsurf_converter()
+
+        self._surface = self._converter.pyflatsurf_surface()
+        self.V2 = self._converter._V2
 
         # We construct a spanning set of edges, that is a subset of the
         # edges that form a basis of H_1(S, Sigma; Z)

--- a/flatsurf/geometry/gl2r_orbit_closure.py
+++ b/flatsurf/geometry/gl2r_orbit_closure.py
@@ -151,8 +151,7 @@ class GL2ROrbitClosure:
         from flatsurf.geometry.translation_surface import TranslationSurface
         if isinstance(surface, TranslationSurface):
             base_ring = surface.base_ring()
-            from .pyflatsurf_conversion import FlatsurfConverter
-            self._converter = FlatsurfConverter(surface)
+            self._converter = surface.pyflatsurf_converter()
             self._surface = self._converter.pyflatsurf_surface()
             self.V2 = self._converter._V2
         else:

--- a/flatsurf/geometry/half_dilation_surface.py
+++ b/flatsurf/geometry/half_dilation_surface.py
@@ -76,8 +76,8 @@ class HalfDilationSurface(SimilaritySurface):
         if not is_Matrix(m):
             from sage.matrix.constructor import matrix
             m = matrix(2, 2, m)
-        elif m.dimensions != (2, 2):
-            raise NotImplementedError("Only implemented for 2x2 matrices.")
+        elif m.dimensions() != (2, 2):
+            raise ValueError("must be a 2x2 matrix")
         # TODO: why returning a copy here!?
         return self.__class__(GL2RImageSurface(self, m)).copy()
 

--- a/flatsurf/geometry/half_dilation_surface.py
+++ b/flatsurf/geometry/half_dilation_surface.py
@@ -71,7 +71,7 @@ class HalfDilationSurface(SimilaritySurface):
 
             sage: s = AA(2).sqrt() * translation_surfaces.square_torus()
             sage: s.base_ring()
-            AA
+            Algebraic Real Field
         """
         if not is_Matrix(m):
             from sage.matrix.constructor import matrix

--- a/flatsurf/geometry/half_translation_surface.py
+++ b/flatsurf/geometry/half_translation_surface.py
@@ -278,4 +278,8 @@ class HalfTranslationSurface(HalfDilationSurface, RationalConeSurface):
         for (p1,e1),(p2,e2) in self.edge_iterator(gluings=True):
             S.set_edge_pairing(relabelling[p1], e1, relabelling[p2], e2)
 
-        return (type(self)(S), M)
+        S.set_immutable()
+        surface = type(self)(S)
+        surface.set_immutable()
+
+        return (surface, M)

--- a/flatsurf/geometry/pyflatsurf_conversion.py
+++ b/flatsurf/geometry/pyflatsurf_conversion.py
@@ -265,7 +265,7 @@ class FlatsurfConverter:
             sage: from flatsurf import translation_surfaces
             sage: from flatsurf.geometry.pyflatsurf_conversion import FlatsurfConverter
             sage: S = translation_surfaces.cathedral(1, 1)
-            sage: f = S.flatsurf_converter() # optional: pyflatsurf
+            sage: f = S.pyflatsurf_converter() # optional: pyflatsurf
             sage: f.flow_decomposition((1, 0)) # optional: pyflatsurf
             FlowDecomposition with 5 cylinders, 0 minimal components and 0 undetermined components
         """
@@ -320,7 +320,7 @@ def to_pyflatsurf(S):
         sage: from flatsurf.geometry.pyflatsurf_conversion import to_pyflatsurf
         sage: T = translation_surfaces.cathedral(1, 1)
         sage: to_pyflatsurf(T) # optional: pyflatsurf
-        FlatTriangulationCombinatorial(...)
+        FlatTriangulationCombinatorial...
     """
     return S.pyflatsurf_converter().pyflatsurf_surface()
 
@@ -441,10 +441,12 @@ def from_pyflatsurf(T):
         0
         sage: for i in range(5): S.set_edge_pairing(0, i, 0, 5+i)
         sage: M = TranslationSurface(S)
-        sage: X = GL2ROrbitClosure(M)  # optional: pyflatsurf
-        sage: D0 = list(X.decompositions(2))[2]  # optional: pyflatsurf
+        sage: M.set_immutable()
+        sage: f = M.pyflatsurf_converter() # optional: pyflatsurf
+        sage: D0 = list(f.flow_decompositions(2))[2]  # optional: pyflatsurf
         sage: T0 = D0.triangulation()  # optional: pyflatsurf
         sage: S0 = from_pyflatsurf(T0)  # optional: pyflatsurf
+        sage: S0 # optional: pyflatsurf
         TranslationSurface built from 8 polygons
         sage: to_pyflatsurf(S0) is T0 # optional: pyflatsurf
         True

--- a/flatsurf/geometry/pyflatsurf_conversion.py
+++ b/flatsurf/geometry/pyflatsurf_conversion.py
@@ -78,10 +78,6 @@ def _cycle_decomposition(p):
     return cycles
 
 
-# TODO:
-# - make proper caching (at class level? in the similarity surface?)
-# - make it possible to initialize it from a pyflatsurf surface
-# - move flow decomposition access directly on similarity surface?
 class FlatsurfConverter:
     r"""
     Conversion between sage-flatsurf and libflatsurf/pyflatsurf.

--- a/flatsurf/geometry/pyflatsurf_conversion.py
+++ b/flatsurf/geometry/pyflatsurf_conversion.py
@@ -371,12 +371,32 @@ class FlatsurfConverter:
     def saddle_connection_to_pyflatsurf(self, sc):
         raise NotImplementedError
 
-    def saddle_connection_from_pyflatsurf(self, sc):
+    def saddle_connection_from_pyflatsurf(self, sc, check=True):
+        r"""
+        EXAMPLES::
+
+            sage: from flatsurf import translation_surfaces
+            sage: s = translation_surfaces.square_torus()
+            sage: for sc in s._pyflatsurf.codomain().connections().bound(3r):
+            ....:     print(s._pyflatsurf.saddle_connection_from_pyflatsurf(sc))
+            Saddle connection ...
+            ...
+
+            sage: set(s.saddle_connections(3*3)) == set(s._pyflatsurf.saddle_connection_from_pyflatsurf(sc) for sc in s._pyflatsurf.codomain().connections().bound(3r))
+            True
+        """
         h_start = sc.source()
-        f_start, e_start = self.half_edge_from_pyflatsurf(h_start)
-        hend = sc.target()
-        f_end, e_end = self.half_edge_from_pyflatsurf(h_end)
-        raise NotImplementedError
+        f_start, e_start, _ = self._half_edge_section[h_start.index()]
+        h_end = sc.target()
+        f_end, e_end, _ = self._half_edge_section[h_end.index()]
+        v = self.vector_space()(sc.vector())
+        v = self.vector_space()._isomorphic_vector_space(v)
+        S = self.domain()
+        poly = S.polygon(f_start)
+        from .surface_objects import SaddleConnection
+        return SaddleConnection(surface=S, start_data=(f_start, e_start),
+                direction=v, end_data=(f_end, e_end), end_direction=-v,
+                holonomy=v, end_holonomy=-v, check=check)
 
     def point_to_pyflatsurf(self, p):
         raise NotImplementedError

--- a/flatsurf/geometry/pyflatsurf_conversion.py
+++ b/flatsurf/geometry/pyflatsurf_conversion.py
@@ -230,9 +230,12 @@ class FlatsurfConverter:
         S.set_immutable()
 
         from flatsurf.geometry.translation_surface import TranslationSurface
+        from pyflatsurf.vector import Vectors
 
         self._surface = TranslationSurface(S)
+        self._surface.set_immutable()
         self._pyflatsurf_surface = T
+        self._V2 = Vectors(self._surface.base_ring())
 
     def sage_flatsurf_surface(self):
         return self._surface

--- a/flatsurf/geometry/similarity_surface.py
+++ b/flatsurf/geometry/similarity_surface.py
@@ -2361,3 +2361,15 @@ class SimilaritySurface(SageObject):
             h = h + 3*hash(edgepair)
         self._hash=h
         return h
+
+    def pyflatsurf_converter(self):
+        try:
+            return self._converter
+        except AttributeError:
+            pass
+
+        if self.is_mutable():
+            raise ValueError("mutable surface; apply .set_immutable() first")
+        from .pyflatsurf_conversion import FlatsurfConverter
+        self._converter = FlatsurfConverter(self)
+        return self._converter

--- a/flatsurf/geometry/similarity_surface.py
+++ b/flatsurf/geometry/similarity_surface.py
@@ -27,6 +27,7 @@ from six.moves import range
 from six import iteritems
 
 from sage.misc.cachefunc import cached_method
+from sage.misc.lazy_attribute import lazy_attribute
 from sage.misc.sage_unittest import TestSuite
 
 from sage.structure.sage_object import SageObject
@@ -2362,14 +2363,9 @@ class SimilaritySurface(SageObject):
         self._hash=h
         return h
 
-    def pyflatsurf_converter(self):
-        try:
-            return self._converter
-        except AttributeError:
-            pass
-
+    @lazy_attribute
+    def _pyflatsurf(self):
         if self.is_mutable():
-            raise ValueError("mutable surface; apply .set_immutable() first")
+            raise ValueError("mutable surface; make your surface immutable first by calling .set_immutable()")
         from .pyflatsurf_conversion import FlatsurfConverter
-        self._converter = FlatsurfConverter(self)
-        return self._converter
+        return FlatsurfConverter(self)

--- a/test/geometry/test_pyflatsurf_conversion.py
+++ b/test/geometry/test_pyflatsurf_conversion.py
@@ -50,7 +50,6 @@ def sage_flatsurf_surface_sample():
     for g in [3, 4]:
         surfaces.append(translation_surfaces.arnoux_yoccoz(g))
 
-
     for n in [3, 17]:
         surfaces.append(translation_surfaces.ward(n))
 
@@ -91,11 +90,10 @@ def test_origami2():
 
 def test_to_pyflatsurf(sage_flatsurf_surface_sample):
     for S in sage_flatsurf_surface_sample:
-        f = S.pyflatsurf_converter()
-        T = f.pyflatsurf_surface()
+        f = S._pyflatsurf
+        T = f.codomain()
 
-        assert S.pyflatsurf_converter() is f
-        assert f.sage_flatsurf_surface() is S
+        assert f.domain() is S
 
         for e in S.edge_iterator():
             assert f.half_edge_from_pyflatsurf(f.half_edge_to_pyflatsurf(e)) == e, S
@@ -106,13 +104,13 @@ def test_to_pyflatsurf(sage_flatsurf_surface_sample):
 
 
 def test_from_pyflatsurf(pyflatsurf_surface_sample):
+    from flatsurf.geometry.pyflatsurf_conversion import FlatsurfConverter
     for T in pyflatsurf_surface_sample:
-        S = from_pyflatsurf(T)
-        f = S.pyflatsurf_converter()
+        f = FlatsurfConverter.from_pyflatsurf(T)
+        S = f.domain()
 
-        assert f.pyflatsurf_surface() is T
-        assert S.pyflatsurf_converter() is f
-        assert f.sage_flatsurf_surface() is S
+        assert not S.is_mutable()
+        assert f.codomain() == T
         
         for e in S.edge_iterator():
             assert f.half_edge_from_pyflatsurf(f.half_edge_to_pyflatsurf(e)) == e, T


### PR DESCRIPTION
This PR introduces a `FlatsurfConverter` class that could be used to pass around objects (such as singularities, points, segments, ...) between a fixed `sage-flatsurf` surface and a fixed `pyflatsurf` flat triangulation. Its constructor incorporates the code of the conversion functions `from_pyflatsurf` and `to_pyflatsurf`.

Partially solves #126.
Fixes #193.

- [ ] NEWS
- [ ] choose a better name than `FlatsurfConverter` ?
- [ ] clarify the status of `FlatsurConverter.flow_decomposition` that was moved from `GL2ROrbitClosure.decomposition`
- [ ] implement saddle connection conversion
- [ ] implement point conversion