### PR TITLE
Run meaningful binder tests in CI

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -15,7 +15,36 @@ jobs:
       uses: flatsurf/actions/conda-forge-build@main
       with:
         recipe: recipe
-        channels: http://conda.anaconda.org/flatsurf
+    - uses: conda-incubator/setup-miniconda@v2
+      with: {
+        mamba-version: "*",
+        channels: "conda-forge",
+        # Default Python version for binder:
+        # https://github.com/jupyterhub/repo2docker/blob/master/repo2docker/buildpacks/conda/environment.yml
+        python-version: "3.7.12",
+        channel-priority: true }
+    - name: Install package like binder would
+      shell: bash -l {0}
+      run: |
+        wget -O repo2docker.yml https://github.com/jupyterhub/repo2docker/raw/main/repo2docker/buildpacks/conda/environment.yml
+        mamba install -n test --quiet -y pytest pytest-xdist
+        mamba env update -n test --quiet -f repo2docker.yml
+        sed 's/  - sage-flatsurf=.*/  - local::sage-flatsurf/' < binder/environment.yml > environment.binder.yml
+        mamba env update -n test --quiet -f environment.binder.yml
+        conda list
+    - name: Initialize cppyy
+      shell: bash -l {0}
+      run: |
+        # Show message about cppyy regenerating pre-compiled headers so it does not show during the tests
+        python -c 'import cppyy' || true
+    - name: Run SageMath doctests
+      shell: bash -l {0}
+      run: |
+        export PYTHONPATH=test/disable-pytest:$PYTHONPATH
+        sage -tp --force-lib --long --optional=sage,flipper,eantic,exactreal,pyflatsurf flatsurf doc
+    - name: Run pytest
+      shell: bash -l {0}
+      run: pytest -n auto
     - uses: actions/upload-artifact@v2
       with:
         name: conda-packages
@@ -24,3 +53,7 @@ jobs:
       with:
         user: flatsurf
         token: ${{ secrets.BINSTAR_TOKEN }}
+
+env:
+  MAKEFLAGS: -j2
+  SAGE_NUM_THREADS: 2

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -29,8 +29,8 @@ jobs:
         wget -O repo2docker.yml https://github.com/jupyterhub/repo2docker/raw/main/repo2docker/buildpacks/conda/environment.yml
         mamba install -n test --quiet -y pytest pytest-xdist
         mamba env update -n test --quiet -f repo2docker.yml
-        conda config --set custom_channels.build file://${{ github.workspace }}/conda-build
-        sed 's/  - sage-flatsurf=.*/  - build::sage-flatsurf/' < binder/environment.yml > environment.binder.yml
+        conda config --set 'custom_channels.conda-build' file://${{ github.workspace }}
+        sed 's/  - sage-flatsurf=.*/  - conda-build::sage-flatsurf/' < binder/environment.yml > environment.binder.yml
         mamba env update -n test --quiet -f environment.binder.yml
         conda list
     - name: Initialize cppyy

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -29,7 +29,8 @@ jobs:
         wget -O repo2docker.yml https://github.com/jupyterhub/repo2docker/raw/main/repo2docker/buildpacks/conda/environment.yml
         mamba install -n test --quiet -y pytest pytest-xdist
         mamba env update -n test --quiet -f repo2docker.yml
-        sed 's/  - sage-flatsurf=.*/  - local::sage-flatsurf/' < binder/environment.yml > environment.binder.yml
+        conda config --set custom_channels.build file://${{ github.workspace }}/conda-build
+        sed 's/  - sage-flatsurf=.*/  - build::sage-flatsurf/' < binder/environment.yml > environment.binder.yml
         mamba env update -n test --quiet -f environment.binder.yml
         conda list
     - name: Initialize cppyy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,11 +34,6 @@ jobs:
             environment: "environment.yml"
             python: "3.9.10"
           - optionals: "sage,flipper,eantic,exactreal,pyflatsurf"
-            environment: "binder"
-            # Default Python version for binder:
-            # https://github.com/jupyterhub/repo2docker/blob/master/repo2docker/buildpacks/conda/environment.yml
-            python: "3.7.12"
-          - optionals: "sage,flipper,eantic,exactreal,pyflatsurf"
             environment: "flatsurf.yml"
             python: "3.9.10"
     steps:
@@ -66,15 +61,6 @@ jobs:
           mamba env update -n test --quiet -f flatsurf.yml
           conda list
         if: ${{ matrix.environment == 'flatsurf.yml' }}
-      - name: Install dependencies (binder)
-        shell: bash -l {0}
-        run: |
-          wget -O repo2docker.yml https://github.com/jupyterhub/repo2docker/raw/main/repo2docker/buildpacks/conda/environment.yml
-          mamba install -n test --quiet -y pytest pytest-xdist
-          mamba env update -n test --quiet -f repo2docker.yml
-          mamba env update -n test --quiet -f binder/environment.yml
-          conda list
-        if: ${{ matrix.environment == 'binder' }}
       - name: Install sage-flatsurf
         shell: bash -l {0}
         run: |

--- a/doc/news/bindertest.rst
+++ b/doc/news/bindertest.rst
@@ -1,0 +1,3 @@
+**Fixed:**
+
+* Fixed automated testing for binder by using a package very closely ressembling the one from conda-forge which will be used by binder.


### PR DESCRIPTION
Currently, the binder tests do not test much since the they install sage-flatsurf from conda-forge and not the one from the pull request. We try to fix this here by running the binder tests after we built the conda-forge package for the (otherwise unused) flatsurf channel.