### PR TITLE
Drop deprecated functions

### DIFF
--- a/doc/news/deprecated.rst
+++ b/doc/news/deprecated.rst
@@ -1,0 +1,3 @@
+**Removed:**
+
+* Removed long deprecated functions namely `HalfDilationSurface.GL2R_mapping()`, `regular_octagon()`, `Similarity.a()`, `Similarity.b()`, `Similarity.t()`, `Similarity.s()`, `SimilaritySurfaceTangentVector.singularity()`, `Surface.make_immutable()`, `GraphicalSurface.make_adjacent_and_visible()`, `SimilaritySurface.minimal_translation_surface()`, `SegmentInPolygon.start_point()`, `SegmentInPolygon.start_direction()`, `SegmentInPolygon.end_point()`, `SegmentInPolygon.end_direction()`.

--- a/flatsurf/geometry/half_dilation_surface.py
+++ b/flatsurf/geometry/half_dilation_surface.py
@@ -33,16 +33,7 @@ class HalfDilationSurface(SimilaritySurface):
     the oriented case, have a look at
     :meth:`flatsurf.dilation_surface.DilationSurface`.
     """
-    def GL2R_mapping(self, matrix):
-        r"""
-        Deprecated. Use apply_matrix instead.
 
-        Apply a 2x2 matrix to the polygons making up this surface. 
-        Returns the flatsurf.geometry.SurfaceMapping from this surface to its image.
-        """
-        deprecation(13109, "GL2R_mapping is deprecated. Use apply_matrix(mapping=True) instead.")
-        return GL2RMapping(self, matrix)
-        
     def __rmul__(self,matrix):
         r"""
         EXAMPLES::

--- a/flatsurf/geometry/polygon.py
+++ b/flatsurf/geometry/polygon.py
@@ -2970,8 +2970,8 @@ class PolygonsConstructor:
 polygons = PolygonsConstructor()
 
 def regular_octagon(field=None):
-    from sage.misc.superseded import deprecation
-    deprecation(33, "Do not use this function anymore but regular_ngon(8)")
+    from warnings import warn
+    warn("regular_octagon() has been deprecated and will be removed in a future version of sage-flatsurf. See https://github.com/flatsurf/sage-flatsurf/issues/33.")
     return polygons.regular_ngon(8)
 
 

--- a/flatsurf/geometry/polygon.py
+++ b/flatsurf/geometry/polygon.py
@@ -2967,12 +2967,8 @@ class PolygonsConstructor:
         else:
             return Polygons(base_ring)(vertices=vertices, edges=edges, base_point=base_point)
 
-polygons = PolygonsConstructor()
 
-def regular_octagon(field=None):
-    from warnings import warn
-    warn("regular_octagon() has been deprecated and will be removed in a future version of sage-flatsurf. See https://github.com/flatsurf/sage-flatsurf/issues/33.")
-    return polygons.regular_ngon(8)
+polygons = PolygonsConstructor()
 
 
 class PolygonCreator():

--- a/flatsurf/geometry/similarity.py
+++ b/flatsurf/geometry/similarity.py
@@ -399,28 +399,6 @@ class Similarity(MultiplicativeGroupElement):
         M = self.parent()._matrix_space_2x2()
         return M([self._a, -self._sign*self._b, self._b,  self._sign*self._a])
 
-    # OLD AND DEPRECATED
-
-    def a(self):
-        from warnings import warn
-        warn("SimilarityGroup.a() has been deprecated and will be removed in a future version of sage-flatsurf.")
-
-        return self._a
-
-    def b(self):
-        from warnings import warn
-        warn("SimilarityGroup.b() has been deprecated and will be removed in a future version of sage-flatsurf.")
-        return self._b
-
-    def s(self):
-        from warnings import warn
-        warn("SimilarityGroup.s() has been deprecated and will be removed in a future version of sage-flatsurf.")
-        return self._s
-
-    def t(self):
-        from warnings import warn
-        warn("SimilarityGroup.t() has been deprecated and will be removed in a future version of sage-flatsurf.")
-        return self._t
 
 class SimilarityGroup(UniqueRepresentation, Group):
     r"""

--- a/flatsurf/geometry/similarity.py
+++ b/flatsurf/geometry/similarity.py
@@ -402,23 +402,24 @@ class Similarity(MultiplicativeGroupElement):
     # OLD AND DEPRECATED
 
     def a(self):
-        from sage.misc.superseded import deprecation
-        deprecation(42, "Do not use .a()")
+        from warnings import warn
+        warn("SimilarityGroup.a() has been deprecated and will be removed in a future version of sage-flatsurf.")
+
         return self._a
 
     def b(self):
-        from sage.misc.superseded import deprecation
-        deprecation(42, "Do not use .b()")
+        from warnings import warn
+        warn("SimilarityGroup.b() has been deprecated and will be removed in a future version of sage-flatsurf.")
         return self._b
 
     def s(self):
-        from sage.misc.superseded import deprecation
-        deprecation(42, "Do not use .s()")
+        from warnings import warn
+        warn("SimilarityGroup.s() has been deprecated and will be removed in a future version of sage-flatsurf.")
         return self._s
 
     def t(self):
-        from sage.misc.superseded import deprecation
-        deprecation(42, "Do not use .t()")
+        from warnings import warn
+        warn("SimilarityGroup.t() has been deprecated and will be removed in a future version of sage-flatsurf.")
         return self._t
 
 class SimilarityGroup(UniqueRepresentation, Group):

--- a/flatsurf/geometry/similarity_surface.py
+++ b/flatsurf/geometry/similarity_surface.py
@@ -1359,20 +1359,6 @@ class SimilaritySurface(SageObject):
             return TranslationSurface(MinimalPlanarCover(self))
         raise ValueError("Provided cover_type is not supported.")
 
-    def minimal_translation_cover(self):
-        r"""
-        Return the minimal translation cover.
-
-        "Be careful that if the surface is not built from one polygon, this is
-        not the smallest translation cover of the surface." - Vincent
-
-        "I disagree with the prior statement. Can you provide an example?" -Pat
-        """
-        from warnings import warn
-        warn("SimilaritySurface.minimal_translation_cover() has been deprecated and will be removed in a future version of sage-flatsurf.")
-        from flatsurf.geometry.translation_surface import MinimalTranslationCover, TranslationSurface
-        return TranslationSurface(MinimalTranslationCover(self))
-
     def vector_space(self):
         r"""
         Return the vector space in which self naturally embeds.

--- a/flatsurf/geometry/similarity_surface.py
+++ b/flatsurf/geometry/similarity_surface.py
@@ -1368,8 +1368,8 @@ class SimilaritySurface(SageObject):
 
         "I disagree with the prior statement. Can you provide an example?" -Pat
         """
-        from sage.misc.superseded import deprecation
-        deprecation(13109, "minimal_translation_cover is deprecated. Use minimal_cover(cover_type = \"translation\") instead.")
+        from warnings import warn
+        warn("SimilaritySurface.minimal_translation_cover() has been deprecated and will be removed in a future version of sage-flatsurf.")
         from flatsurf.geometry.translation_surface import MinimalTranslationCover, TranslationSurface
         return TranslationSurface(MinimalTranslationCover(self))
 

--- a/flatsurf/geometry/straight_line_trajectory.py
+++ b/flatsurf/geometry/straight_line_trajectory.py
@@ -190,23 +190,23 @@ class SegmentInPolygon:
     # DEPRECATED STUFF THAT WILL BE REMOVED
 
     def start_point(self):
-        from sage.misc.superseded import deprecation
-        deprecation(1, "do not use start_point but start().point()")
+        from warnings import warn
+        warn("SegmentInPolygon.start_point() has been deprecated and will be removed in a future version of sage-flatsurf. Use start().point() instead.")
         return self._start.point()
 
     def start_direction(self):
-        from sage.misc.superseded import deprecation
-        deprecation(1, "do not use start_direction but start().vector()")
+        from warnings import warn
+        warn("SegmentInPolygon.start_direction() has been deprecated and will be removed in a future version of sage-flatsurf. Use start().vector() instead.")
         return self._start.vector()
 
     def end_point(self):
-        from sage.misc.superseded import deprecation
-        deprecation(1, "do not use end_point but end().point()")
+        from warnings import warn
+        warn("SegmentInPolygon.end_point() has been deprecated and will be removed in a future version of sage-flatsurf. Use end().point() instead.")
         return self._end.point()
 
     def end_direction(self):
-        from sage.misc.superseded import deprecation
-        deprecation(1, "do not use end_direction but end().vector()")
+        from warnings import warn
+        warn("SegmentInPolygon.end_direction() has been deprecated and will be removed in a future version of sage-flatsurf. Use end().vector() instead.")
         return self._end.vector()
 
 class AbstractStraightLineTrajectory:

--- a/flatsurf/geometry/straight_line_trajectory.py
+++ b/flatsurf/geometry/straight_line_trajectory.py
@@ -187,28 +187,6 @@ class SegmentInPolygon:
         return SegmentInPolygon(self._start.invert()).invert()
 
 
-    # DEPRECATED STUFF THAT WILL BE REMOVED
-
-    def start_point(self):
-        from warnings import warn
-        warn("SegmentInPolygon.start_point() has been deprecated and will be removed in a future version of sage-flatsurf. Use start().point() instead.")
-        return self._start.point()
-
-    def start_direction(self):
-        from warnings import warn
-        warn("SegmentInPolygon.start_direction() has been deprecated and will be removed in a future version of sage-flatsurf. Use start().vector() instead.")
-        return self._start.vector()
-
-    def end_point(self):
-        from warnings import warn
-        warn("SegmentInPolygon.end_point() has been deprecated and will be removed in a future version of sage-flatsurf. Use end().point() instead.")
-        return self._end.point()
-
-    def end_direction(self):
-        from warnings import warn
-        warn("SegmentInPolygon.end_direction() has been deprecated and will be removed in a future version of sage-flatsurf. Use end().vector() instead.")
-        return self._end.vector()
-
 class AbstractStraightLineTrajectory:
     r"""
     You need to implement:

--- a/flatsurf/geometry/surface.py
+++ b/flatsurf/geometry/surface.py
@@ -345,14 +345,6 @@ class Surface(SageObject):
         """
         self._mutable = False
 
-    def make_immutable(self):
-        r"""
-        Mark this surface as immutable.
-        """
-        from warnings import warn
-        warn("Surface.make_immutable() has been deprecated and will be removed in a future version of sage-flatsurf. Use set_immutable() instead.")
-        self._mutable = False
-
     def walker(self):
         r"""
         Return a LabelWalker which walks over the surface in a canonical way.

--- a/flatsurf/geometry/surface.py
+++ b/flatsurf/geometry/surface.py
@@ -349,8 +349,8 @@ class Surface(SageObject):
         r"""
         Mark this surface as immutable.
         """
-        from sage.misc.superseded import deprecation
-        deprecation(13109, "Do not use .make_immutable(). Use .set_immutable() instead.")
+        from warnings import warn
+        warn("Surface.make_immutable() has been deprecated and will be removed in a future version of sage-flatsurf. Use set_immutable() instead.")
         self._mutable = False
 
     def walker(self):

--- a/flatsurf/geometry/tangent_bundle.py
+++ b/flatsurf/geometry/tangent_bundle.py
@@ -159,8 +159,8 @@ class SimilaritySurfaceTangentVector:
 
     def singularity(self):
         r"""Return the index of the vertex."""
-        from sage.misc.superseded import deprecation
-        deprecation(42, "Do not use .singularity(). Use .vertex() instead.")
+        from warnings import warn
+        warn("SimilaritySurfaceTangentVector.singularity() has been deprecated and will be removed in a future version of sage-flatsurf. Use verte() instead.")
         # Note: I want to change this to returning the singularity of the surface instead.
         return self._position.get_vertex()
 

--- a/flatsurf/geometry/tangent_bundle.py
+++ b/flatsurf/geometry/tangent_bundle.py
@@ -157,13 +157,6 @@ class SimilaritySurfaceTangentVector:
         r"""Return the index of the vertex."""
         return self._position.get_vertex()
 
-    def singularity(self):
-        r"""Return the index of the vertex."""
-        from warnings import warn
-        warn("SimilaritySurfaceTangentVector.singularity() has been deprecated and will be removed in a future version of sage-flatsurf. Use verte() instead.")
-        # Note: I want to change this to returning the singularity of the surface instead.
-        return self._position.get_vertex()
-
     def is_in_boundary_of_polygon(self):
         r"""
         Return the truth value of the statement

--- a/flatsurf/graphical/surface.py
+++ b/flatsurf/graphical/surface.py
@@ -595,15 +595,6 @@ class GraphicalSurface:
         if visible:
             self.make_visible(pp)
 
-    def make_adjacent_and_visible(self, p, e, reverse=False):
-        r"""
-        Move the polygon across the prescribed edge so that is adjacent,
-        and make the moved polygon visible.
-        """
-        from warnings import warn
-        warn("GraphicalSurface.make_adjacent_and_visible() has been deprecated and will be removed in a future version of sage-flatsurf. Use make_adjacent() instead.")
-        self.make_adjacent(p, e, reverse=reverse)
-
     def is_adjacent(self,p,e):
         r"""
         Returns the truth value of the statement

--- a/flatsurf/graphical/surface.py
+++ b/flatsurf/graphical/surface.py
@@ -600,8 +600,8 @@ class GraphicalSurface:
         Move the polygon across the prescribed edge so that is adjacent,
         and make the moved polygon visible.
         """
-        from sage.misc.superseded import deprecation
-        deprecation(42, "Do not use .make_adjacent_and_visible(). Use .make_adjacent() instead.")
+        from warnings import warn
+        warn("GraphicalSurface.make_adjacent_and_visible() has been deprecated and will be removed in a future version of sage-flatsurf. Use make_adjacent() instead.")
         self.make_adjacent(p, e, reverse=reverse)
 
     def is_adjacent(self,p,e):


### PR DESCRIPTION
I wanted to replace the SageMath deprecation warnings in the code with generic Python warnings so that the warnings do not link to trac tickets that are unrelated/don't exist anymore. I considered using a library such as Deprecated or deprecation but it turns out that these don't play nicely with SageMath's doctesting framework.

Anyway, actually all the deprecated functionality has been deprecated for at least 3 years, so I guess we can just drop it anyway. That's what I ended up doing. In the future we should not abuse `sage.misc.superseded` anymore but just

```python
from warnings import warn
warn("Class.method() has been deprecated and will be removed from a future version of sage-flatsurf. Use somethingelse() instead. See https://github.com/flatsurf/sage-flatsurf/issues/123.")
```