### PR TITLE
Deprecate Surface_list

### DIFF
--- a/flatsurf/geometry/delaunay.py
+++ b/flatsurf/geometry/delaunay.py
@@ -16,7 +16,7 @@ surfaces.
 from __future__ import absolute_import, print_function, division
 from six.moves import range, map, filter, zip
 
-from flatsurf.geometry.surface import Surface, Surface_list
+from flatsurf.geometry.surface import Surface
 
 
 class LazyTriangulatedSurface(Surface):
@@ -41,21 +41,34 @@ class LazyTriangulatedSurface(Surface):
         sage: from flatsurf.geometry.delaunay import *
         sage: s=translation_surfaces.infinite_staircase()
         sage: ss=TranslationSurface(LazyTriangulatedSurface(s,relabel=True))
+        doctest:warning
+        ...
+        UserWarning: Creating a LazyTriangulatedSurface with relabel=True is deprecated and will be removed in a future version of sage-flatsurf.
+        doctest:warning
+        ...
+        UserWarning: copy(relabel=True) is deprecated and will be removed in a future version of sage-flatsurf. Use relabel() instead.
+        doctest:warning
+        ...
+        UserWarning: Surface_list is deprecated and will be removed from a future version of sage-flaturf. Use Surface_dict instead.
         sage: ss.polygon(0).num_edges()
+        doctest:warning
+        ...
+        UserWarning: subdivide_polygon() without specifying a label is deprecated and will be removed from a future version of sage-flatsurf. Explicitly specify a label instead, e.g., use subdivid_polygon(label=surface.num_polygons()).
         3
         sage: TestSuite(ss).run(skip="_test_pickling")
     """
     def __init__(self, similarity_surface, relabel=True):
+        if relabel:
+            import warnings
+            warnings.warn("Creating a LazyTriangulatedSurface with relabel=True is deprecated and will be removed in a future version of sage-flatsurf.")
 
         if similarity_surface.is_mutable():
             raise ValueError("Surface must be immutable.")
         
         # This surface will converge to the Delaunay Triangulation
-        self._s = similarity_surface.copy(relabel=relabel, lazy=True, \
-            mutable=True)
+        self._s = similarity_surface.copy(relabel=relabel, lazy=True, mutable=True)
 
-        Surface.__init__(self, self._s.base_ring(), self._s.base_label(), \
-            mutable=False, finite=self._s.is_finite())
+        Surface.__init__(self, self._s.base_ring(), self._s.base_label(), mutable=False, finite=self._s.is_finite())
 
     def polygon(self, lab):
         r"""
@@ -106,10 +119,25 @@ class LazyDelaunayTriangulatedSurface(Surface):
         sage: from flatsurf.geometry.delaunay import *
         sage: s=translation_surfaces.infinite_staircase()
         sage: ss=TranslationSurface(LazyDelaunayTriangulatedSurface(s,relabel=True))
+        doctest:warning
+        ...
+        UserWarning: Creating a LazyDelaunayTriangulatedSurface with relabel=True is deprecated and will be removed in a future version of sage-flatsurf.
+        doctest:warning
+        ...
+        UserWarning: copy(relabel=True) is deprecated and will be removed in a future version of sage-flatsurf. Use relabel() instead.
+        doctest:warning
+        ...
+        UserWarning: Surface_list is deprecated and will be removed from a future version of sage-flaturf. Use Surface_dict instead.
+        doctest:warning
+        ...
+        UserWarning: subdivide_polygon() without specifying a label is deprecated and will be removed from a future version of sage-flatsurf. Explicitly specify a label instead, e.g., use subdivid_polygon(label=surface.num_polygons()).
         sage: ss.polygon(0).num_edges()
         3
         sage: TestSuite(ss).run(skip="_test_pickling")
         sage: ss.is_delaunay_triangulated(limit=100)
+        doctest:warning
+        ...
+        UserWarning: subdivide_polygon() without specifying a label is deprecated and will be removed from a future version of sage-flatsurf. Explicitly specify a label instead, e.g., use subdivid_polygon(label=surface.num_polygons()).
         True
 
     Chamanara example::
@@ -137,6 +165,10 @@ class LazyDelaunayTriangulatedSurface(Surface):
         r"""
         Construct a lazy Delaunay triangulation of the provided similarity_surface.
         """
+        if relabel:
+            import warnings
+            warnings.warn("Creating a LazyDelaunayTriangulatedSurface with relabel=True is deprecated and will be removed in a future version of sage-flatsurf.")
+
         if similarity_surface.underlying_surface().is_mutable():
             raise ValueError("Surface must be immutable.")
 
@@ -327,6 +359,18 @@ class LazyDelaunaySurface(LazyDelaunayTriangulatedSurface):
         sage: s=chamanara_surface(QQ(1/2))
         sage: m=matrix([[3,4],[-4,3]])*matrix([[4,0],[0,1/4]])
         sage: ss=TranslationSurface(LazyDelaunaySurface(m*s))
+        doctest:warning
+        ...
+        UserWarning: Creating a LazyDelaunaySurface with relabel=True is deprecated and will be removed in a future version of sage-flatsurf.
+        doctest:warning
+        ...
+        UserWarning: copy(relabel=True) is deprecated and will be removed in a future version of sage-flatsurf. Use relabel() instead.
+        doctest:warning
+        ...
+        UserWarning: Surface_list is deprecated and will be removed from a future version of sage-flaturf. Use Surface_dict instead.
+        doctest:warning
+        ...
+        UserWarning: subdivide_polygon() without specifying a label is deprecated and will be removed from a future version of sage-flatsurf. Explicitly specify a label instead, e.g., use subdivid_polygon(label=surface.num_polygons()).
         sage: ss.is_delaunay_decomposed(limit=100)
         True
         sage: TestSuite(ss).run(skip="_test_pickling")
@@ -335,8 +379,11 @@ class LazyDelaunaySurface(LazyDelaunayTriangulatedSurface):
     def __init__(self, similarity_surface, direction=None, relabel=True):
         r"""
         Construct a lazy Delaunay triangulation of the provided similarity_surface.
-        
         """
+        if relabel:
+            import warnings
+            warnings.warn("Creating a LazyDelaunaySurface with relabel=True is deprecated and will be removed in a future version of sage-flatsurf.")
+
         if similarity_surface.underlying_surface().is_mutable():
             raise ValueError("Surface must be immutable.")
 

--- a/flatsurf/geometry/half_dilation_surface.py
+++ b/flatsurf/geometry/half_dilation_surface.py
@@ -131,12 +131,12 @@ class HalfDilationSurface(SimilaritySurface):
         TESTS::
 
             sage: from flatsurf import *
-            sage: s = Surface_list(base_ring=QQ)
+            sage: s = Surface_dict(base_ring=QQ)
             sage: t1 = polygons((1,0),(-1,1),(0,-1))
             sage: t2 = polygons((0,1),(-1,0),(1,-1))
-            sage: s.add_polygon(polygons(vertices=[(0,0), (1,0), (0,1)]))
+            sage: s.add_polygon(polygons(vertices=[(0,0), (1,0), (0,1)]), label=0)
             0
-            sage: s.add_polygon(polygons(vertices=[(1,1), (0,1), (1,0)]))
+            sage: s.add_polygon(polygons(vertices=[(1,1), (0,1), (1,0)]), label=1)
             1
             sage: s.change_polygon_gluings(0, [(1,0), (1,1), (1,2)])
             sage: s = TranslationSurface(s)
@@ -247,8 +247,8 @@ class HalfDilationSurface(SimilaritySurface):
                 from flatsurf.geometry.surface import Surface_dict
                 s = self.__class__(Surface_dict(surface=self,mutable=True))
         else:
-            from flatsurf.geometry.surface import Surface_list
-            s = self.__class__(Surface_list(surface=self.triangulate(in_place=in_place),mutable=True))
+            from flatsurf.geometry.surface import Surface_dict
+            s = self.__class__(Surface_dict(surface=self.triangulate(in_place=in_place),mutable=True))
 
         if direction is None:
             base_ring = self.base_ring()
@@ -341,6 +341,9 @@ class GL2RImageSurface(Surface):
             pp,ee = self._s.opposite_edge(p,polygon.num_edges()-1-e)
             polygon2 = self._s.polygon(pp)
             return pp,polygon2.num_edges()-1-ee
+
+    def unused_label(self, ignore=()):
+        return self._s.unused_label(ignore=ignore)
 
 class GL2RMapping(SurfaceMapping):
     r"""

--- a/flatsurf/geometry/half_translation_surface.py
+++ b/flatsurf/geometry/half_translation_surface.py
@@ -265,14 +265,14 @@ class HalfTranslationSurface(HalfDilationSurface, RationalConeSurface):
             K, new_hols, _ = subfield_from_elements(self.base_ring(), hols)
 
         from .polygon import ConvexPolygons
-        from .surface import Surface_list
-        S = Surface_list(K)
+        from .surface import Surface_dict
+        S = Surface_dict(K)
         C = ConvexPolygons(K)
         relabelling = {}
         k = 0
         for lab in self.label_iterator():
             m = self.polygon(lab).num_edges()
-            relabelling[lab] = S.add_polygon(C(edges=[(new_hols[k + 2*i], new_hols[k + 2*i+1]) for i in range(m)]))
+            relabelling[lab] = S.add_polygon(C(edges=[(new_hols[k + 2*i], new_hols[k + 2*i+1]) for i in range(m)]), label=S.num_polygons())
             k += 2 * m
 
         for (p1,e1),(p2,e2) in self.edge_iterator(gluings=True):

--- a/flatsurf/geometry/l_infinity_delaunay_cells.py
+++ b/flatsurf/geometry/l_infinity_delaunay_cells.py
@@ -340,13 +340,17 @@ class LInfinityMarkedTriangulation:
         from sage.rings.rational_field import QQ
         C = ConvexPolygons(QQ)
 
+        from flatsurf import Surface_dict, TranslationSurface
+        S = Surface_dict(QQ)
+
         triangles = []
         for p in range(self._n):
             e1 = (b[6*p], b[6*p+1])
             e2 = (b[6*p+2], b[6*p+3])
             e3 = (b[6*p+4], b[6*p+5])
-            triangles.append(C([e1,e2,e3]))
-        
-        from .surface import surface_list_from_polygons_and_gluings
-        from .translation_surface import TranslationSurface
-        return TranslationSurface(surface_list_from_polygons_and_gluings(triangles, self._edge_identifications))
+            S.add_polygon(C([e1,e2,e3]), label=S.num_polygons())
+
+        for (p, e), (pp, ee) in self._edge_identifications.items():
+            S.set_edge_pairing(p, e, pp, ee)
+
+        return TranslationSurface(S)

--- a/flatsurf/geometry/minimal_cover.py
+++ b/flatsurf/geometry/minimal_cover.py
@@ -13,13 +13,13 @@ class MinimalTranslationCover(Surface):
 
     EXAMPLES::
 
-        sage: from flatsurf import *
+        sage: from flatsurf import Surface_dict, ConvexPolygons, SimilaritySurface, TranslationSurface
         sage: from flatsurf.geometry.minimal_cover import MinimalTranslationCover
-        sage: s = Surface_list(QQ)
+        sage: s = Surface_dict(QQ)
         sage: P = ConvexPolygons(QQ)
-        sage: s.add_polygon(P(vertices=[(0,0),(5,0),(0,5)]))
+        sage: s.add_polygon(P(vertices=[(0,0),(5,0),(0,5)]), label=0)
         0
-        sage: s.add_polygon(P(vertices=[(0,0),(3,4),(-4,3)]))
+        sage: s.add_polygon(P(vertices=[(0,0),(3,4),(-4,3)]), label=1)
         1
         sage: s.change_polygon_gluings(0,[(1,2),(1,1),(1,0)])
         sage: s.set_immutable()
@@ -56,11 +56,12 @@ class MinimalTranslationCover(Surface):
             from flatsurf.geometry.rational_cone_surface import RationalConeSurface
             finite = True
             if not isinstance(self._ss, RationalConeSurface):
-                ss_copy = self._ss.reposition_polygons(relabel=True)
+                ss_copy = self._ss.reposition_polygons()
                 try:
                     rcs = RationalConeSurface(ss_copy)
                     rcs._test_edge_matrix()
                 except AssertionError:
+                    # TODO: No, we do not get to catch an assertion.
                     finite = False
 
         self._F = self._ss.base_ring()
@@ -82,6 +83,13 @@ class MinimalTranslationCover(Surface):
         bb = b * m[0][0] + a * m[1][0]
         return ((p2, aa, bb), e2)
 
+    def unused_label(self, ignore=()):
+        label = 0
+        while True:
+            if label not in ignore:
+                return label
+            label += 1
+
 
 class MinimalHalfTranslationCover(Surface):
     r"""
@@ -89,13 +97,13 @@ class MinimalHalfTranslationCover(Surface):
 
     EXAMPLES::
 
-        sage: from flatsurf import *
+        sage: from flatsurf import Surface_dict, ConvexPolygons, SimilaritySurface, HalfTranslationSurface
         sage: from flatsurf.geometry.minimal_cover import MinimalHalfTranslationCover
-        sage: s = Surface_list(QQ)
+        sage: s = Surface_dict(QQ)
         sage: P = ConvexPolygons(QQ)
-        sage: s.add_polygon(P(vertices=[(0,0),(5,0),(0,5)]))
+        sage: s.add_polygon(P(vertices=[(0,0),(5,0),(0,5)]), label=0)
         0
-        sage: s.add_polygon(P(vertices=[(0,0),(3,4),(-4,3)]))
+        sage: s.add_polygon(P(vertices=[(0,0),(3,4),(-4,3)]), label=1)
         1
         sage: s.change_polygon_gluings(0,[(1,2),(1,1),(1,0)])
         sage: s.set_immutable()
@@ -132,11 +140,12 @@ class MinimalHalfTranslationCover(Surface):
             from flatsurf.geometry.rational_cone_surface import RationalConeSurface
             finite = True
             if not isinstance(self._ss, RationalConeSurface):
-                ss_copy = self._ss.reposition_polygons(relabel=True)
+                ss_copy = self._ss.reposition_polygons()
                 try:
                     rcs = RationalConeSurface(ss_copy)
                     rcs._test_edge_matrix()
                 except AssertionError:
+                    # TODO: No, we don't get to catch assertion errors. Remove this everywhere.
                     # print("Warning: Could be indicating infinite surface falsely.")
                     finite=False
 

--- a/flatsurf/geometry/pyflatsurf_conversion.py
+++ b/flatsurf/geometry/pyflatsurf_conversion.py
@@ -248,13 +248,13 @@ def from_pyflatsurf(T):
     Verify that #137 has been resolved::
 
         sage: from flatsurf import polygons
-        sage: from flatsurf.geometry.surface import Surface_list
+        sage: from flatsurf.geometry.surface import Surface_dict
         sage: from flatsurf.geometry.translation_surface import TranslationSurface
         sage: from flatsurf.geometry.gl2r_orbit_closure import GL2ROrbitClosure
         sage: from flatsurf.geometry.pyflatsurf_conversion import from_pyflatsurf
         sage: P = polygons.regular_ngon(10)
-        sage: S = Surface_list(P.base_ring())
-        sage: S.add_polygon(P)
+        sage: S = Surface_dict(P.base_ring())
+        sage: S.add_polygon(P, label=0)
         0
         sage: for i in range(5): S.set_edge_pairing(0, i, 0, 5+i)
         sage: M = TranslationSurface(S)
@@ -271,8 +271,8 @@ def from_pyflatsurf(T):
 
     ring = sage_ring(T)
 
-    from flatsurf.geometry.surface import Surface_list
-    S = Surface_list(ring)
+    from flatsurf.geometry.surface import Surface_dict
+    S = Surface_dict(ring)
 
     from flatsurf.geometry.polygon import ConvexPolygons
     P = ConvexPolygons(ring)
@@ -287,7 +287,7 @@ def from_pyflatsurf(T):
         vectors = [T.fromHalfEdge(he) for he in face]
         vectors = [V([ring(to_sage_ring(v.x())), ring(to_sage_ring(v.y()))]) for v in vectors]
         triangle = P(vectors)
-        face_id = S.add_polygon(triangle)
+        face_id = S.add_polygon(triangle, label=S.num_polygons())
 
         assert(a not in half_edges)
         half_edges[a] = (face_id, 0)

--- a/flatsurf/geometry/rational_similarity_surface.py
+++ b/flatsurf/geometry/rational_similarity_surface.py
@@ -11,12 +11,12 @@ class RationalSimilaritySurface(SimilaritySurface):
 
     EXAMPLES::
 
-        sage: from flatsurf import *
-        sage: s = Surface_list(AA)
+        sage: from flatsurf import Surface_dict, ConvexPolygons
+        sage: s = Surface_dict(AA)
         sage: CP = ConvexPolygons(AA)
-        sage: s.add_polygon(CP(vertices=[(0,0),(2,0),(1,1)]))
+        sage: s.add_polygon(CP(vertices=[(0,0),(2,0),(1,1)]), label=0)
         0
-        sage: s.add_polygon(CP(vertices=[(0,0),(1,0),(1,sqrt(3))]))
+        sage: s.add_polygon(CP(vertices=[(0,0),(1,0),(1,sqrt(3))]), label=1)
         1
         sage: for i in range(3):
         ....:     s.change_edge_gluing(0,i,1,i)
@@ -29,12 +29,11 @@ class RationalSimilaritySurface(SimilaritySurface):
 
     Example of a similarity surface which is not rational::
 
-        sage: from flatsurf import *
-        sage: s = Surface_list(QQ)
+        sage: s = Surface_dict(QQ)
         sage: CP = ConvexPolygons(QQ)
-        sage: s.add_polygon(CP(vertices=[(0,0),(2,0),(1,1)]))
+        sage: s.add_polygon(CP(vertices=[(0,0),(2,0),(1,1)]), label=0)
         0
-        sage: s.add_polygon(CP(vertices=[(0,0),(1,0),(1,2)]))
+        sage: s.add_polygon(CP(vertices=[(0,0),(1,0),(1,2)]), label=1)
         1
         sage: for i in range(3):
         ....:     s.change_edge_gluing(0,i,1,i)

--- a/flatsurf/geometry/similarity_surface_generators.py
+++ b/flatsurf/geometry/similarity_surface_generators.py
@@ -34,7 +34,7 @@ ZZ_2 = ZZ(2)
 
 from .polygon import polygons, ConvexPolygons, Polygon, ConvexPolygon, build_faces
 
-from .surface import Surface, Surface_list
+from .surface import Surface, Surface_dict
 from .translation_surface import TranslationSurface
 from .dilation_surface import DilationSurface
 from .similarity_surface import SimilaritySurface
@@ -441,9 +441,9 @@ class SimilaritySurfaceGenerators:
             SimilaritySurface built from 2 polygons
             sage: TestSuite(ex).run()
         """
-        s = Surface_list(base_ring=QQ)
-        s.add_polygon(polygons(vertices=[(0,0), (2,-2), (2,0)],ring=QQ)) # gets label 0
-        s.add_polygon(polygons(vertices=[(0,0), (2,0), (1,3)],ring=QQ)) # gets label 1
+        s = Surface_dict(base_ring=QQ)
+        s.add_polygon(polygons(vertices=[(0,0), (2,-2), (2,0)],ring=QQ), label=0)
+        s.add_polygon(polygons(vertices=[(0,0), (2,0), (1,3)],ring=QQ), label=1)
         s.change_polygon_gluings(0, [(1,1), (1,2), (1,0)])
         s.set_immutable()
         return SimilaritySurface(s)
@@ -460,8 +460,8 @@ class SimilaritySurfaceGenerators:
             sage: s = similarity_surfaces.self_glued_polygon(p)
             sage: TestSuite(s).run()
         """
-        s = Surface_list(base_ring=P.base_ring(), mutable=True)
-        s.add_polygon(P,[(0,i) for i in range(P.num_edges())])
+        s = Surface_dict(base_ring=P.base_ring(), mutable=True)
+        s.add_polygon(P,[(0,i) for i in range(P.num_edges())], label=0)
         s.set_immutable()
         return HalfTranslationSurface(s)
 
@@ -571,11 +571,11 @@ class SimilaritySurfaceGenerators:
 
         m = len(P)
         Q = []
-        surface = Surface_list(base_ring=base_ring)
+        surface = Surface_dict(base_ring=base_ring)
         for p in P:
-            surface.add_polygon(p)
+            surface.add_polygon(p, label=surface.num_polygons())
         for p in P:
-            surface.add_polygon(polygons(edges=[V((-x,y)) for x,y in reversed(p.edges())]))
+            surface.add_polygon(polygons(edges=[V((-x,y)) for x,y in reversed(p.edges())]), label=surface.num_polygons())
         for (p1,e1,p2,e2) in internal_edges:
             surface.set_edge_pairing(p1, e1, p2, e2)
             ne1 = surface.polygon(p1).num_edges()
@@ -605,9 +605,9 @@ class SimilaritySurfaceGenerators:
         r = matrix(2, [-1,0,0,1])
         Q = polygons(edges=[r*v for v in reversed(P.edges())])
 
-        surface = Surface_list(base_ring = P.base_ring())
-        surface.add_polygon(P) # gets label 0)
-        surface.add_polygon(Q) # gets label 1
+        surface = Surface_dict(base_ring = P.base_ring())
+        surface.add_polygon(P, label=0)
+        surface.add_polygon(Q, label=1)
         surface.change_polygon_gluings(0,[(1,n-i-1) for i in range(n)])
         surface.set_immutable()
         return ConeSurface(surface)
@@ -631,9 +631,9 @@ class SimilaritySurfaceGenerators:
             F = F.fraction_field()
         V = VectorSpace(F,2)
         P = ConvexPolygons(F)
-        s = Surface_list(base_ring=F)
-        s.add_polygon(P([V((w,0)),V((-w,h)),V((0,-h))])) # gets label 0
-        s.add_polygon(P([V((0,h)),V((-w,-h)),V((w,0))])) # gets label 1
+        s = Surface_dict(base_ring=F)
+        s.add_polygon(P([V((w,0)),V((-w,h)),V((0,-h))]), label=0)
+        s.add_polygon(P([V((0,h)),V((-w,-h)),V((w,0))]), label=1)
         s.change_polygon_gluings(0,[(1,2),(1,1),(1,0)])
         s.set_immutable()
         return ConeSurface(s)
@@ -668,10 +668,10 @@ class DilationSurfaceGenerators:
             sage: TestSuite(ds).run()
 
         """
-        s = Surface_list(base_ring=a.parent().fraction_field())
+        s = Surface_dict(base_ring=a.parent().fraction_field())
         CP = ConvexPolygons(s.base_ring())
-        s.add_polygon(CP(edges=[(0,1),(-1,0),(0,-1),(1,0)])) # label 0
-        s.add_polygon(CP(edges=[(0,1),(-a,0),(0,-1),(a,0)])) # label 1
+        s.add_polygon(CP(edges=[(0,1),(-1,0),(0,-1),(1,0)]), label=0)
+        s.add_polygon(CP(edges=[(0,1),(-a,0),(0,-1),(a,0)]), label=1)
         s.change_edge_gluing(0, 0, 1, 2)
         s.change_edge_gluing(0, 1, 1, 3)
         s.change_edge_gluing(0, 2, 1, 0)
@@ -716,15 +716,15 @@ class DilationSurfaceGenerators:
             sage: TestSuite(ds).run()
         """
         field = Sequence([a, b, c, d]).universe().fraction_field()
-        s = Surface_list(base_ring=QQ)
+        s = Surface_dict(base_ring=QQ)
         CP = ConvexPolygons(field)
         hexagon = CP(edges=[(a,0), (1-a,b), (0,1-b), (-c,0), (c-1,-d), (0,d-1)])
-        s.add_polygon(hexagon) # polygon 0
+        s.add_polygon(hexagon, label=0)
         s.change_base_label(0)
         triangle1 = CP(edges=[(1-a,0), (0,b), (a-1,-b)])
-        s.add_polygon(triangle1) # polygon 1
+        s.add_polygon(triangle1, label=1)
         triangle2 = CP(edges=[(1-c,d), (c-1,0), (0,-d)])
-        s.add_polygon(triangle2) # polygon 2
+        s.add_polygon(triangle2, label=2)
         s.change_edge_gluing(0, 0, 0, 3)
         s.change_edge_gluing(0, 2, 0, 5)
         s.change_edge_gluing(0, 1, 1, 2)
@@ -778,10 +778,12 @@ class HalfTranslationSurfaceGenerators:
 
         Prev = [C(vertices=[(x, -y) for x,y in reversed(p.vertices())]) for p in P]
 
-        S = Surface_list(base_ring = C.base_ring())
+        S = Surface_dict(base_ring = C.base_ring())
         S.rename("StepBilliard(w=[%s], h=[%s])" % (', '.join(map(str, w)), ', '.join(map(str, h))))
-        S.add_polygons(P)    # get labels 0, ..., n-1
-        S.add_polygons(Prev) # get labels n, n+1, ..., 2n-1
+        for p in P:
+            S.add_polygon(p, label=S.num_polygons())
+        for p in Prev:
+            S.add_polygon(p, label=S.num_polygons())
 
         # reflection gluings
         # (gluings between the polygon and its reflection)
@@ -861,9 +863,9 @@ class TranslationSurfaceGenerators:
             field = py_scalar_parent(field)
         if not field.is_field():
             field = field.fraction_field()
-        s = Surface_list(base_ring=field)
+        s = Surface_dict(base_ring=field)
         p = polygons(vertices=[(0,0), u, u+v, v], base_ring=field)
-        s.add_polygon(p, [(0,2),(0,3),(0,0),(0,1)])
+        s.add_polygon(p, [(0,2),(0,3),(0,0),(0,1)], label=0)
         s.set_immutable()
         return TranslationSurface(s)
 
@@ -881,8 +883,8 @@ class TranslationSurfaceGenerators:
             sage: TestSuite(s).run()
         """
         p = polygons.regular_ngon(2*n)
-        s = Surface_list(base_ring=p.base_ring())
-        s.add_polygon(p,[ ( 0, (i+n)%(2*n) ) for i in range(2*n)] )
+        s = Surface_dict(base_ring=p.base_ring())
+        s.add_polygon(p,[ ( 0, (i+n)%(2*n) ) for i in range(2*n)] , label=0)
         s.set_immutable()
         return TranslationSurface(s)
 
@@ -899,10 +901,10 @@ class TranslationSurfaceGenerators:
         """
         from sage.matrix.constructor import Matrix
         p = polygons.regular_ngon(n)
-        s = Surface_list(base_ring=p.base_ring())
+        s = Surface_dict(base_ring=p.base_ring())
         m = Matrix([[-1,0],[0,-1]])
-        s.add_polygon(p) # label=0
-        s.add_polygon(m*p, [(0,i) for i in range(n)])
+        s.add_polygon(p, label=0)
+        s.add_polygon(m*p, [(0,i) for i in range(n)], label=1)
         s.set_immutable()
         return TranslationSurface(s)
 
@@ -1031,12 +1033,12 @@ class TranslationSurfaceGenerators:
 
         # (lambda,lambda) square on top
         # twisted (w,0), (t,h)
-        s = Surface_list(base_ring=K)
+        s = Surface_dict(base_ring=K)
         if rel:
             if rel < 0 or rel > w - l:
                 raise ValueError("invalid rel argument")
-            s.add_polygon(polygons(vertices=[(0,0),(l,0),(l+rel,l),(rel,l)], ring=K))
-            s.add_polygon(polygons(vertices=[(0,0),(rel,0),(rel+l,0),(w,0),(w+t,h),(l+rel+t,h),(t+l,h),(t,h)], ring=K))
+            s.add_polygon(polygons(vertices=[(0,0),(l,0),(l+rel,l),(rel,l)], ring=K), label=0)
+            s.add_polygon(polygons(vertices=[(0,0),(rel,0),(rel+l,0),(w,0),(w+t,h),(l+rel+t,h),(t+l,h),(t,h)], ring=K), label=1)
             s.set_edge_pairing(0, 1, 0, 3)
             s.set_edge_pairing(0, 0, 1, 6)
             s.set_edge_pairing(0, 2, 1, 1)
@@ -1044,8 +1046,8 @@ class TranslationSurfaceGenerators:
             s.set_edge_pairing(1, 3, 1, 7)
             s.set_edge_pairing(1, 0, 1, 5)
         else:
-            s.add_polygon(polygons(vertices=[(0,0),(l,0),(l,l),(0,l)], ring=K))
-            s.add_polygon(polygons(vertices=[(0,0),(l,0),(w,0),(w+t,h),(l+t,h),(t,h)], ring=K))
+            s.add_polygon(polygons(vertices=[(0,0),(l,0),(l,l),(0,l)], ring=K), label=0)
+            s.add_polygon(polygons(vertices=[(0,0),(l,0),(w,0),(w+t,h),(l+t,h),(t,h)], ring=K), label=1)
             s.set_edge_pairing(0, 1, 0, 3)
             s.set_edge_pairing(0, 0, 1, 4)
             s.set_edge_pairing(0, 2, 1, 0)
@@ -1091,10 +1093,10 @@ class TranslationSurfaceGenerators:
         if not field.is_field():
             field = field.fraction_field()
 
-        s = Surface_list(base_ring=field)
-        s.add_polygon(polygons((l3,0),(0,l2),(-l3,0),(0,-l2), ring=field))
-        s.add_polygon(polygons((l3,0),(0,l1),(-l3,0),(0,-l1), ring=field))
-        s.add_polygon(polygons((l4,0),(0,l2),(-l4,0),(0,-l2), ring=field))
+        s = Surface_dict(base_ring=field)
+        s.add_polygon(polygons((l3,0),(0,l2),(-l3,0),(0,-l2), ring=field), label=0)
+        s.add_polygon(polygons((l3,0),(0,l1),(-l3,0),(0,-l1), ring=field), label=1)
+        s.add_polygon(polygons((l4,0),(0,l2),(-l4,0),(0,-l2), ring=field), label=2)
         s.change_edge_gluing(0,0,1,2)
         s.change_edge_gluing(0,1,2,3)
         s.change_edge_gluing(0,2,1,0)
@@ -1122,10 +1124,10 @@ class TranslationSurfaceGenerators:
         o = ZZ_2*polygons.regular_ngon(2*n)
         p1 = polygons(*[o.edge((2*i+n)%(2*n)) for i in range(n)])
         p2 = polygons(*[o.edge((2*i+n+1)%(2*n)) for i in range(n)])
-        s = Surface_list(base_ring=o.parent().field())
-        s.add_polygon(o)
-        s.add_polygon(p1)
-        s.add_polygon(p2)
+        s = Surface_dict(base_ring=o.parent().field())
+        s.add_polygon(o, label=0)
+        s.add_polygon(p1, label=1)
+        s.add_polygon(p2, label=2)
         s.change_polygon_gluings(1, [(0,2*i) for i in range(n)])
         s.change_polygon_gluings(2, [(0,2*i+1) for i in range(n)])
         s.set_immutable()
@@ -1200,16 +1202,16 @@ class TranslationSurfaceGenerators:
         a = ring(a)
         b = ring(b)
         P = ConvexPolygons(ring)
-        s = Surface_list(base_ring=ring)
+        s = Surface_dict(base_ring=ring)
         half = QQ((1,2))
         p0 = P(vertices=[(0,0),(a,0),(a,1),(0,1)])
         p1 = P(vertices=[(a,0),(a,-b),(a+half,-b-half),(a+1,-b),(a+1,0),(a+1,1),(a+1,b+1),(a+half,b+1+half),(a,b+1),(a,1)])
         p2 = P(vertices=[(a+1,0),(2*a+1,0),(2*a+1,1),(a+1,1)])
         p3 = P(vertices=[(2*a+1,0), (2*a+1+half,-half),(4*a+1+half,-half),(4*a+2,0),(4*a+2,1),(4*a+1+half,1+half),(2*a+1+half,1+half),(2*a+1,1)])
-        s.add_polygon(p0)
-        s.add_polygon(p1)
-        s.add_polygon(p2)
-        s.add_polygon(p3)
+        s.add_polygon(p0, label=0)
+        s.add_polygon(p1, label=1)
+        s.add_polygon(p2, label=2)
+        s.add_polygon(p3, label=3)
         s.set_edge_pairing(0, 0, 0, 2)
         s.set_edge_pairing(0, 1, 1, 9)
         s.set_edge_pairing(0, 3, 3, 3)
@@ -1294,20 +1296,20 @@ class TranslationSurfaceGenerators:
         for i in range(1,g+1):
             q[i]=V(( (2*a-a**i-a**(i+1))/(2*(1-a)), (a-a**(g-i+2))/(1-a) ))
         P = ConvexPolygons(field)
-        s = Surface_list(field)
+        s = Surface_dict(field)
         T = [None] * (2*g+1)
         Tp = [None] * (2*g+1)
         from sage.matrix.constructor import Matrix
         m=Matrix([[1,0],[0,-1]])
         for i in range(1,g+1):
             # T_i is (P_0,Q_i,Q_{i-1})
-            T[i]=s.add_polygon(P(edges=[ q[i]-p[0], q[i-1]-q[i], p[0]-q[i-1] ]))
+            T[i]=s.add_polygon(P(edges=[ q[i]-p[0], q[i-1]-q[i], p[0]-q[i-1] ]), label=s.num_polygons())
             # T_{g+i} is (P_i,Q_{i-1},Q_{i})
-            T[g+i]=s.add_polygon(P(edges=[ q[i-1]-p[i], q[i]-q[i-1], p[i]-q[i] ]))
+            T[g+i]=s.add_polygon(P(edges=[ q[i-1]-p[i], q[i]-q[i-1], p[i]-q[i] ]), label=s.num_polygons())
             # T'_i is (P'_0,Q'_{i-1},Q'_i)
-            Tp[i]=s.add_polygon(m*s.polygon(T[i]))
+            Tp[i]=s.add_polygon(m*s.polygon(T[i]), label=s.num_polygons())
             # T'_{g+i} is (P'_i,Q'_i, Q'_{i-1})
-            Tp[g+i]=s.add_polygon(m*s.polygon(T[g+i]))
+            Tp[g+i]=s.add_polygon(m*s.polygon(T[g+i]), label=s.num_polygons())
         for i in range(1,g):
             s.change_edge_gluing(T[i],0,T[i+1],2)
             s.change_edge_gluing(Tp[i],2,Tp[i+1],0)
@@ -1372,8 +1374,6 @@ class TranslationSurfaceGenerators:
             sage: from flatsurf.geometry.similarity_surface_generators import flipper_nf_element_to_sage
             sage: a = flipper_nf_element_to_sage(h.dilatation())  # optional - flipper
         """
-        from .surface import surface_list_from_polygons_and_gluings
-
         f = h.flat_structure()
 
         x = next(itervalues(f.edge_vectors)).x
@@ -1387,19 +1387,22 @@ class TranslationSurfaceGenerators:
 
         C = ConvexPolygons(K)
 
-        polys = []
-        adjacencies = {}
-        for i,t in enumerate(f.triangulation):
-            for j,k in enumerate(t):
-                adjacencies[(i,j)] = to_polygon_number[~k]
+        S = Surface_dict(K)
+
+        for i, t in enumerate(f.triangulation):
             try:
                 poly = C([edge_vectors[i] for i in tuple(t)])
             except ValueError:
                 raise ValueError("t = {}, edges = {}".format(
                     t, [edge_vectors[i].n(digits=6) for i in t]))
-            polys.append(poly)
 
-        return HalfTranslationSurface(surface_list_from_polygons_and_gluings(polys, adjacencies))
+            S.add_polygon(poly, label=S.num_polygons())
+
+        for i, t in enumerate(f.triangulation):
+            for j, k in enumerate(t):
+                S.set_edge_pairing(i, j, to_polygon_number[~k])
+
+        return HalfTranslationSurface(S)
 
     @staticmethod
     def origami(r, u, rr=None, uu=None, domain=None):

--- a/flatsurf/geometry/straight_line_trajectory.py
+++ b/flatsurf/geometry/straight_line_trajectory.py
@@ -589,10 +589,10 @@ class StraightLineTrajectory(AbstractStraightLineTrajectory):
 
         An example in a cone surface covered by the torus::
 
-            sage: from flatsurf import *
+            sage: from flatsurf import Surface_dict, RationalConeSurface, polygons
             sage: p = polygons.square()
-            sage: s = Surface_list(base_ring=p.base_ring())
-            sage: s.add_polygon(p,[(0,3),(0,2),(0,1),(0,0)])
+            sage: s = Surface_dict(base_ring=p.base_ring())
+            sage: s.add_polygon(p,[(0,3),(0,2),(0,1),(0,0)], 0)
             0
             sage: s.set_immutable()
             sage: t = RationalConeSurface(s)

--- a/flatsurf/geometry/thurston_veech.py
+++ b/flatsurf/geometry/thurston_veech.py
@@ -46,7 +46,7 @@ from surface_dynamics.flat_surfaces.origamis.origami import Origami
 from surface_dynamics.misc.permutation import perm_dense_cycles
 
 from .polygon import ConvexPolygons
-from .surface import Surface_list
+from .surface import Surface_dict
 from .translation_surface import TranslationSurface
 
 class ThurstonVeech:
@@ -169,9 +169,9 @@ class ThurstonVeech:
             vi = v[self._vcycles[i]]
             P.append(C(edges=[(vi,0),(0,hi),(-vi,0),(0,-hi)]))
 
-        surface = Surface_list(base_ring=K)
+        surface = Surface_dict(base_ring=K)
         for p in P:
-            surface.add_polygon(p)
+            surface.add_polygon(p, label=surface.num_polygons())
         r = self._o.r_tuple()
         u = self._o.u_tuple()
         for i in range(self._o.nb_squares()):

--- a/flatsurf/geometry/translation_surface.py
+++ b/flatsurf/geometry/translation_surface.py
@@ -109,11 +109,12 @@ class TranslationSurface(HalfTranslationSurface, DilationSurface):
             sage: TestSuite(ss).run()
 
         Make sure first vertex is sent to origin::
-            sage: from flatsurf import *
+
+            sage: from flatsurf import ConvexPolygons, Surface_dict, TranslationSurface
             sage: P = ConvexPolygons(QQ)
             sage: p = P(vertices = ([(1,1),(2,1),(2,2),(1,2)]))
-            sage: s = Surface_list(QQ)
-            sage: s.add_polygon(p)
+            sage: s = Surface_dict(QQ)
+            sage: s.add_polygon(p, label=0)
             0
             sage: s.change_polygon_gluings(0, [(0,2),(0,3),(0,0),(0,1)])
             sage: s.change_base_label(0)
@@ -651,6 +652,14 @@ class AbstractOrigami(Surface):
         if e==3:
             return self.left(p),1
         raise ValueError
+
+    def unused_label(self, ignore=()):
+        import uuid
+        while True:
+            new_label = str(uuid.uuid4())
+            if new_label in self._domain or new_label in ignore:
+                continue
+            return new_label
 
 
 class Origami(AbstractOrigami):

--- a/flatsurf/geometry/xml.py
+++ b/flatsurf/geometry/xml.py
@@ -4,12 +4,22 @@ readable format using XML.
 
 We also have a function to recreate the surface from the string/file.
 
+.. WARNING::
+
+    This entire functionality is deprecated and will be removed in a future version of sage-flatsurf.
+    To our knowledge nobody is using this functionality. There are also problems in
+    the implementation (manually building an XML string) and it only works for
+    the deprecated :class:`Surface_list`.
+
 EXAMPLES::
 
     sage: from flatsurf import *
     sage: from flatsurf.geometry.xml import *
     sage: s=translation_surfaces.square_torus().underlying_surface()
     sage: ss=surface_from_xml_string(surface_to_xml_string(s))
+    doctest:warning
+    ...
+    UserWarning: surface_from_xml_string() is deprecated and will be removed in a future version of sage-flatsurf
     sage: print(ss==s)
     True
 """
@@ -34,6 +44,9 @@ def surface_to_xml_string(s, complain=True):
     Also the surface should be defined over the rationals. Otherwise a ValueError is raised, which
     can be disabled by setting complain=False.
     """
+    import warnings
+    warnings.warn("surface_to_xml_string() is deprecated and will be removed in a future version of sage-flatsurf")
+
     if not s.is_finite():
         raise ValueError("Can only xml encode a finite surface.")
     from flatsurf.geometry.similarity_surface import SimilaritySurface
@@ -124,6 +137,9 @@ def surface_to_xml_file(s,filename,complain=True):
     
     The complain flag is passed to surface_to_xml_string.
     """
+    import warnings
+    warnings.warn("surface_to_xml_file() is deprecated and will be removed in a future version of sage-flatsurf")
+
     string = surface_to_xml_string(s,complain=complain)
     f = open(filename, 'w')
     f.write('<?xml version="1.0"?>\n')
@@ -137,6 +153,9 @@ def surface_from_xml_string(string):
     Currently, this works only if the surface stored was a Surface_list and the surface was defined
     over QQ.
     """
+    import warnings
+    warnings.warn("surface_from_xml_string() is deprecated and will be removed in a future version of sage-flatsurf")
+
     import xml.etree.ElementTree as ET
     tree = ET.fromstring(string)
     return _surface_from_ElementTree(tree)
@@ -148,6 +167,9 @@ def surface_from_xml_file(filename):
     Currently, this works only if the surface stored was a Surface_list and the surface was defined
     over QQ.
     """
+    import warnings
+    warnings.warn("surface_from_xml_file() is deprecated and will be removed in a future version of sage-flatsurf")
+
     import xml.etree.ElementTree as ET
     tree = ET.parse(filename)
     return _surface_from_ElementTree(tree)


### PR DESCRIPTION
We deprecate (or probably just remove) `Surface_list` as it provides no real benefit over `Surface_dict`. The performance gains are minimal in our timing experiments.

Checklist
* [ ] Added an entry in `doc/news/`. <!-- Copy the TEMPLATE.rst to mybranch.rst, fill in the relevant sections, delete the others. -->
* [ ] Added a test for this change.
* [ ] Added new .py files to the documentation in `doc/geometry` or `doc/graphical`.
