### PR TITLE
fix angles() for non-convex polygons

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -28,7 +28,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "sage-flatsurf"
-copyright = u"2016-2023, the sage-flatsurf authors"
+copyright = "2016-2023, the sage-flatsurf authors"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/doc/news/angles.rst
+++ b/doc/news/angles.rst
@@ -1,0 +1,3 @@
+**Fixed:**
+
+* Fixed angles() for half translation surfaces built with non-convex polygons

--- a/flatsurf/geometry/categories/half_translation_surfaces.py
+++ b/flatsurf/geometry/categories/half_translation_surfaces.py
@@ -568,7 +568,7 @@ class HalfTranslationSurfaces(SurfaceCategory):
                             # Note that iteration order here is different for different
                             # versions of Python. Therefore, the output in the doctest
                             # above is random.
-                            pair = p,e = next(iter(edges))
+                            pair = p, e = next(iter(edges))
                             ve = self.polygon(p).edge(e)
                             angle = 0
                             adjacent_edges = []
@@ -576,10 +576,14 @@ class HalfTranslationSurfaces(SurfaceCategory):
                                 adjacent_edges.append(pair)
                                 edges.remove(pair)
                                 poly = self.polygon(p)
-                                f = (e-1) % len(poly.vertices())
+                                f = (e - 1) % len(poly.vertices())
                                 ve = poly.edge(e)
                                 vf = -poly.edge(f)
-                                if ve[0] * vf[1] == ve[1] * vf[0] and ve[0] * vf[0] >= 0 and ve[1] * vf[1] >= 0:
+                                if (
+                                    ve[0] * vf[1] == ve[1] * vf[0]
+                                    and ve[0] * vf[0] >= 0
+                                    and ve[1] * vf[1] >= 0
+                                ):
                                     # aligned vectors (angle 2pi)
                                     if ve[0] == 0:
                                         angle += 1

--- a/flatsurf/geometry/euclidean.py
+++ b/flatsurf/geometry/euclidean.py
@@ -525,6 +525,7 @@ def is_between(e0, e1, f):
         # - f[0] * e1[1] + e1[0] * f[1] > 0
         return e0[1] * f[0] < e0[0] * f[1] or e1[0] * f[1] < e1[1] * f[0]
 
+
 def solve(x, u, y, v):
     r"""
     Return (a,b) so that: x + au = y + bv

--- a/flatsurf/geometry/euclidean.py
+++ b/flatsurf/geometry/euclidean.py
@@ -496,10 +496,13 @@ def is_between(e0, e1, f):
     EXAMPLES::
 
         sage: from flatsurf.geometry.euclidean import is_between
-        sage: V = ZZ^2
-        sage: is_between(V((1, 0)), V((1, 1)), V((2, 1)))
+        sage: is_between((1, 0), (1, 1), (2, 1))
         True
 
+        sage: from itertools import product
+        sage: vecs = [(1, 0), (1, 1), (0, 1), (-1, 1), (-1, 0), (-1, -1), (0, -1), (1, -1)]
+        sage: for (i, vi), (j, vj), (k, vk) in product(enumerate(vecs), repeat=3):
+        ....:     assert is_between(vi, vj, vk) == ((i == j and i != k) or i < k < j or k < j < i or j < i < k), ((i, vi), (j, vj), (k, vk))
     """
     if e0[0] * e1[1] > e1[0] * e0[1]:
         # positive determinant
@@ -510,15 +513,17 @@ def is_between(e0, e1, f):
         return e1[1] * f[0] > e1[0] * f[1] and e0[0] * f[1] > e0[1] * f[0]
     elif e0[0] * e1[1] == e1[0] * e0[1]:
         # aligned vector
-        return e0[0] * f[1] > e0[1] * f[0]
+        if e0[0] * e1[0] >= 0 and e0[1] * e1[1] >= 0:
+            return f[0] * e0[1] != f[1] * e0[0] or f[0] * e0[0] < 0 or f[1] * e0[1] < 0
+        else:
+            return e0[0] * f[1] > e0[1] * f[0]
     else:
         # negative determinant
         # [ e1[0] e0[0] ]^-1 = [ e0[1] -e0[0] ]
         # [ e1[1] e0[1] ]      [-e1[1]  e1[0] ]
         # f[0] * e0[1] - e0[0] * f[1] > 0
         # - f[0] * e1[1] + e1[0] * f[1] > 0
-        return e0[1] * f[0] <= e0[0] * f[1] or e1[0] * f[1] <= e1[1] * f[0]
-
+        return e0[1] * f[0] < e0[0] * f[1] or e1[0] * f[1] < e1[1] * f[0]
 
 def solve(x, u, y, v):
     r"""

--- a/rever.xsh
+++ b/rever.xsh
@@ -48,7 +48,7 @@ $VERSION_BUMP_PATTERNS = [
     ('flatsurf.yml', r"  - sage-flatsurf=", r"  - sage-flatsurf=$VERSION"),
     ('README.md', r'\[!\[Binder\]', r'[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/flatsurf/sage-flatsurf/$VERSION?filepath=doc%2Fexamples)'),
     ('doc/index.rst', r' :target: https://mybinder.org/v2/gh/flatsurf/sage-flatsurf', r' :target: https://mybinder.org/v2/gh/flatsurf/sage-flatsurf/$VERSION?filepath=doc%2Fexamples'),
-    ('doc/conf.py', r'copyright = ', r"copyright = u\"2016-$RELEASE_YEAR, the sage-flatsurf authors\""),
+    ('doc/conf.py', r'copyright = ', r"copyright = \"2016-$RELEASE_YEAR, the sage-flatsurf authors\""),
 ]
 
 $CHANGELOG_FILENAME = 'ChangeLog'


### PR DESCRIPTION
We fix `.angles()` for half-translation surface which used to break with non-convex polygons.

Checklist
* [x] Added an entry in `doc/news/`
* [x] Added a test for this change.