### PR TITLE
Fix caching for mutable surfaces

### DIFF
--- a/doc/cache.rst
+++ b/doc/cache.rst
@@ -1,0 +1,6 @@
+``cache``
+=============
+
+.. automodule:: flatsurf.cache
+   :members:
+   :undoc-members:

--- a/doc/cache.rst
+++ b/doc/cache.rst
@@ -1,5 +1,5 @@
-``cache``
-=============
+The flatsurf.cache Modules
+**************************
 
 .. automodule:: flatsurf.cache
    :members:

--- a/doc/features.rst
+++ b/doc/features.rst
@@ -1,5 +1,5 @@
-``features``
-=============
+The flatsurf.features Modules
+*****************************
 
 .. automodule:: flatsurf.features
    :members:

--- a/doc/features.rst
+++ b/doc/features.rst
@@ -1,0 +1,6 @@
+``features``
+=============
+
+.. automodule:: flatsurf.features
+   :members:
+   :undoc-members:

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -85,3 +85,5 @@ from an interactive SageMath session with |help|_.
 
    geometry
    graphical
+   features
+   cache

--- a/doc/news/cache.rst
+++ b/doc/news/cache.rst
@@ -1,0 +1,3 @@
+**Fixed:**
+
+* Fixed caching of methods on mutable surfaces. Before ``edge_matrix()`` on a mutable surfaces was cached which could lead to wrong results.

--- a/flatsurf/cache.py
+++ b/flatsurf/cache.py
@@ -17,8 +17,9 @@ EXAMPLES::
     sage: S.edge_matrix(0, 0) is S.edge_matrix(0, 0)
     False
 
-When we call :meth:`MutableOrientedSimilaritySurface.set_immutable`, caching is
-enabled for this method::
+When we call
+:meth:`flatsurf.geometry.surface.MutableOrientedSimilaritySurface.set_immutable`,
+caching is enabled for this method::
 
     sage: S.set_immutable()
     sage: S.edge_matrix(0, 0) is S.edge_matrix(0, 0)
@@ -57,8 +58,8 @@ def cached_surface_method(f, name=None, key=None, do_pickle=None):
     r"""
     Make a surface method cached as soon as the surface is immutable.
 
-    This is a drop-in replacement for ``@cached_method`` from SageMath but it
-    does not provide any caching for mutable surfaces.
+    This is a drop-in replacement for :func:`sage.misc.cachefunc.cached_method`
+    from SageMath but it does not provide any caching for mutable surfaces.
     """
     from sage.misc.cachefunc import CachedMethod
 
@@ -72,12 +73,12 @@ def cached_surface_method(f, name=None, key=None, do_pickle=None):
 
 class CachedSurfaceMethodCaller(CachedMethodCaller):
     r"""
-    Adapts the ``CachedMethodCaller`` from SageMath to not do any caching if
-    the defining surface is mutable.
+    Adapts the :class:`sage.misc.cachefunc.CachedMethodCaller` from SageMath to
+    not do any caching if the defining surface is mutable.
 
     Note that this only handles methods with arguments, for methods without
-    arguments, a caller that customizes ``CachedMethodCallerNoArgs`` must be
-    used.
+    arguments, a caller that customizes
+    :class:`sage.misc.cachefunc.CachedMethodCallerNoArgs` must be used.
     """
 
     def __init__(self, cached_caller, *args, **kwargs):
@@ -89,10 +90,11 @@ class CachedSurfaceMethodCaller(CachedMethodCaller):
         r"""
         Invoke the underlying method with the given arguments.
 
-        The underlying ``CachedMethodCaller`` is written in Cython and highly
-        optimized. This method is much slower (by about 250ns per call.)
-        However, once the surface is immutable, this method is replaced with
-        the underlying caching one, so the overhead is only paid once.
+        The underlying :class:`sage.misc.cachefunc.CachedMethodCaller` is
+        written in Cython and highly optimized. This method is much slower (by
+        about 250ns per call.) However, once the surface is immutable, this
+        method is replaced with the underlying caching one, so the overhead is
+        only paid once.
         """
         if self._instance.is_mutable():
             return self._instance_call(*args, **kwargs)
@@ -104,8 +106,8 @@ class CachedSurfaceMethodCaller(CachedMethodCaller):
 
 class CachedSurfaceMethod(CachedMethod):
     r"""
-    Customizes a method in a class so that it conditionally enables caching just
-    like SageMath's ``CachedMethod`` does.
+    Customizes a method in a class so that it conditionally enables caching
+    just like SageMath's :class:`sage.misc.cachefunc.CachedMethod` does.
     """
 
     def __init__(self, f, name, key, do_pickle):

--- a/flatsurf/cache.py
+++ b/flatsurf/cache.py
@@ -99,7 +99,7 @@ class CachedSurfaceMethodCaller(CachedMethodCaller):
 
 class CachedSurfaceMethod(CachedMethod):
     r"""
-    Customizes a method in a class so that it conditonally enables caching just
+    Customizes a method in a class so that it conditionally enables caching just
     like SageMath's ``CachedMethod`` does.
     """
     def __init__(self, f, name, key, do_pickle):

--- a/flatsurf/cache.py
+++ b/flatsurf/cache.py
@@ -58,8 +58,9 @@ def cached_surface_method(f, name=None, key=None, do_pickle=None):
     r"""
     Make a surface method cached as soon as the surface is immutable.
 
-    This is a drop-in replacement for :func:`sage.misc.cachefunc.cached_method`
-    from SageMath but it does not provide any caching for mutable surfaces.
+    This is a drop-in replacement for SageMath's
+    ``sage.misc.cachefunc.cached_method`` but it does not provide any caching
+    for mutable surfaces.
     """
     from sage.misc.cachefunc import CachedMethod
 
@@ -73,12 +74,12 @@ def cached_surface_method(f, name=None, key=None, do_pickle=None):
 
 class CachedSurfaceMethodCaller(CachedMethodCaller):
     r"""
-    Adapts the :class:`sage.misc.cachefunc.CachedMethodCaller` from SageMath to
-    not do any caching if the defining surface is mutable.
+    Adapts the ``sage.misc.cachefunc.CachedMethodCaller`` from SageMath to not
+    do any caching if the defining surface is mutable.
 
     Note that this only handles methods with arguments, for methods without
     arguments, a caller that customizes
-    :class:`sage.misc.cachefunc.CachedMethodCallerNoArgs` must be used.
+    ``sage.misc.cachefunc.CachedMethodCallerNoArgs`` must be used.
     """
 
     def __init__(self, cached_caller, *args, **kwargs):
@@ -90,11 +91,11 @@ class CachedSurfaceMethodCaller(CachedMethodCaller):
         r"""
         Invoke the underlying method with the given arguments.
 
-        The underlying :class:`sage.misc.cachefunc.CachedMethodCaller` is
-        written in Cython and highly optimized. This method is much slower (by
-        about 250ns per call.) However, once the surface is immutable, this
-        method is replaced with the underlying caching one, so the overhead is
-        only paid once.
+        The underlying ``sage.misc.cachefunc.CachedMethodCaller`` is written in
+        Cython and highly optimized. This method is much slower (by about 250ns
+        per call.) However, once the surface is immutable, this method is
+        replaced with the underlying caching one, so the overhead is only paid
+        once.
         """
         if self._instance.is_mutable():
             return self._instance_call(*args, **kwargs)
@@ -107,7 +108,7 @@ class CachedSurfaceMethodCaller(CachedMethodCaller):
 class CachedSurfaceMethod(CachedMethod):
     r"""
     Customizes a method in a class so that it conditionally enables caching
-    just like SageMath's :class:`sage.misc.cachefunc.CachedMethod` does.
+    just like SageMath's ``sage.misc.cachefunc.CachedMethod`` does.
     """
 
     def __init__(self, f, name, key, do_pickle):

--- a/flatsurf/cache.py
+++ b/flatsurf/cache.py
@@ -44,7 +44,11 @@ enabled for this method::
 #  along with sage-flatsurf. If not, see <https://www.gnu.org/licenses/>.
 # *********************************************************************
 
-from sage.misc.cachefunc import CachedMethod, CachedMethodCaller, CachedMethodCallerNoArgs
+from sage.misc.cachefunc import (
+    CachedMethod,
+    CachedMethodCaller,
+    CachedMethodCallerNoArgs,
+)
 from sage.misc.decorators import decorator_keywords
 
 
@@ -75,6 +79,7 @@ class CachedSurfaceMethodCaller(CachedMethodCaller):
     arguments, a caller that customizes ``CachedMethodCallerNoArgs`` must be
     used.
     """
+
     def __init__(self, cached_caller, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -102,6 +107,7 @@ class CachedSurfaceMethod(CachedMethod):
     Customizes a method in a class so that it conditionally enables caching just
     like SageMath's ``CachedMethod`` does.
     """
+
     def __init__(self, f, name, key, do_pickle):
         super().__init__(f, name, key, do_pickle)
         self._key = key
@@ -112,9 +118,19 @@ class CachedSurfaceMethod(CachedMethod):
 
         if inst is not None and inst.is_mutable():
             if isinstance(caller, CachedMethodCallerNoArgs):
-                raise NotImplementedError("cannot cache parameterless cached methods yet")
+                raise NotImplementedError(
+                    "cannot cache parameterless cached methods yet"
+                )
             else:
-                caller = CachedSurfaceMethodCaller(caller, self, inst, cache=self._get_instance_cache(inst), name=caller.__name__, key=self._key, do_pickle=self._do_pickle)
+                caller = CachedSurfaceMethodCaller(
+                    caller,
+                    self,
+                    inst,
+                    cache=self._get_instance_cache(inst),
+                    name=caller.__name__,
+                    key=self._key,
+                    do_pickle=self._do_pickle,
+                )
 
         if inst is not None:
             setattr(inst, caller.__name__, caller)

--- a/flatsurf/cache.py
+++ b/flatsurf/cache.py
@@ -18,7 +18,7 @@ EXAMPLES::
     False
 
 When we call
-:meth:`flatsurf.geometry.surface.MutableOrientedSimilaritySurface.set_immutable`,
+:meth:`flatsurf.geometry.surface.MutablePolygonalSurface.set_immutable`,
 caching is enabled for this method::
 
     sage: S.set_immutable()

--- a/flatsurf/cache.py
+++ b/flatsurf/cache.py
@@ -1,0 +1,96 @@
+r"""
+Adapts :mod:`sage.misc.cachefunc` for sage-flatsurf.
+
+Some methods on surfaces in sage-flatsurf benefit a lot from caching. However,
+we cannot simply put ``@cached_method`` on these surfaces since they are often
+defined in a class that is used by both, mutable and immutable surfaces.
+Caching for mutable surfaces would be incorrect, or we would have to manually
+clear caches upon mutation.
+
+Therefore, we add a decorator ``@cached_surface_method`` that only caches if
+the surface is immutable.
+
+EXAMPLES::
+
+    sage: from flatsurf import MutableOrientedSimilaritySurface, translation_surfaces
+    sage: S = MutableOrientedSimilaritySurface.from_surface(translation_surfaces.square_torus())
+    sage: S.edge_matrix(0, 0) is S.edge_matrix(0, 0)
+    False
+
+When we call :meth:`MutableOrientedSimilaritySurface.set_immutable`, caching is
+enabled for this method::
+
+    sage: S.set_immutable()
+    sage: S.edge_matrix(0, 0) is S.edge_matrix(0, 0)
+    True
+
+"""
+# ****************************************************************************
+#  This file is part of sage-flatsurf.
+#
+#        Copyright (C) 2024 Julian Rüth
+#
+#  sage-flatsurf is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  sage-flatsurf is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with sage-flatsurf. If not, see <https://www.gnu.org/licenses/>.
+# *********************************************************************
+
+from sage.misc.cachefunc import CachedMethod, CachedMethodCaller, CachedMethodCallerNoArgs
+from sage.misc.decorators import decorator_keywords
+
+
+@decorator_keywords
+def cached_surface_method(f, name=None, key=None, do_pickle=None):
+    from sage.misc.cachefunc import CachedMethod
+
+    fname = name or f.__name__
+    if fname.startswith("__"):
+        # Copy the special names and wrap CachedSpecialMethod to make this work.
+        raise NotImplementedError("cannot cache special methods of surfaces yet")
+
+    return CachedSurfaceMethod(f, name=name, key=key, do_pickle=do_pickle)
+
+
+class CachedSurfaceMethodCaller(CachedMethodCaller):
+    def __init__(self, cached_caller, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self._cached_caller = cached_caller
+
+    def __call__(self, *args, **kwargs):
+        if self._instance.is_mutable():
+            return self._instance_call(*args, **kwargs)
+
+        setattr(self._instance, self.__name__, self._cached_caller)
+
+        return self._cached_caller.__call__(*args, **kwargs)
+
+
+class CachedSurfaceMethod(CachedMethod):
+    def __init__(self, f, name, key, do_pickle):
+        super().__init__(f, name, key, do_pickle)
+        self._key = key
+        self._do_pickle = do_pickle
+
+    def __get__(self, inst, cls):
+        caller = super().__get__(inst, cls)
+
+        if inst is not None and inst.is_mutable():
+            if isinstance(caller, CachedMethodCallerNoArgs):
+                raise NotImplementedError("cannot cache parameterless cached methods yet")
+            else:
+                caller = CachedSurfaceMethodCaller(caller, self, inst, cache=self._get_instance_cache(inst), name=caller.__name__, key=self._key, do_pickle=self._do_pickle)
+
+        if inst is not None:
+            setattr(inst, caller.__name__, caller)
+
+        return caller

--- a/flatsurf/geometry/categories/similarity_surfaces.py
+++ b/flatsurf/geometry/categories/similarity_surfaces.py
@@ -120,7 +120,8 @@ from flatsurf.geometry.categories.surface_category import (
     SurfaceCategoryWithAxiom,
 )
 from sage.categories.category_with_axiom import all_axioms
-from sage.misc.cachefunc import cached_method, cached_in_parent_method
+from flatsurf.cache import cached_surface_method
+from sage.misc.cachefunc import cached_method
 from sage.all import QQ, AA
 
 
@@ -484,6 +485,11 @@ class SimilaritySurfaces(SurfaceCategory):
                     sage: T._refine_category_(S.category())  # make angle() available
                     sage: T(0, 0).angle()
                     1
+                    sage: T(0, 0).angle() is T(0, 0).angle()
+                    False
+
+                ::
+
                     sage: T.glue((0, 0), (0, 2))
                     sage: T(0, 0).angle()
                     3/8
@@ -494,12 +500,7 @@ class SimilaritySurfaces(SurfaceCategory):
 
                 """
                 if self.is_vertex():
-                    angle = self._angle_vertex(numerical=numerical)
-
-                    if self.parent().is_mutable():
-                        self._angle_vertex.clear_cache()  # pylint: disable=no-member
-
-                    return angle
+                    return self.parent()._angle_vertex(self, numerical=numerical)
 
                 from sage.all import QQ, RR
 
@@ -520,31 +521,6 @@ class SimilaritySurfaces(SurfaceCategory):
                         return ring(0.5)
 
                 return ring.one()
-
-            @cached_in_parent_method
-            def _angle_vertex(self, numerical):
-                r"""
-                Return the total angle at this vertex in multiples of 2π.
-
-                INPUT:
-
-                - ``numerical`` -- a boolean; whether to return the angle as a
-                  floating point number.
-
-                EXAMPLES::
-
-                    sage: from flatsurf import Polygon, similarity_surfaces
-                    sage: P = Polygon(vertices=[(0, 0), (2, 0), (1, 4), (0, 5)])
-                    sage: S = similarity_surfaces.self_glued_polygon(P)
-                    sage: S(0, 0)._angle_vertex(numerical=False)
-                    1
-
-                """
-                turns, start, end = self.turns()
-
-                from flatsurf.geometry.euclidean import angle
-
-                return turns + angle(start, end, numerical=numerical)
 
             def turns(self, start_edge=None, start_holonomy=None):
                 r"""
@@ -1049,7 +1025,32 @@ class SimilaritySurfaces(SurfaceCategory):
 
                 return [p.angle(numerical=numerical) for p in self.vertices()]
 
-            @cached_method
+            @cached_surface_method
+            def _angle_vertex(self, vertex, numerical):
+                r"""
+                Return the total angle at this vertex in multiples of 2π.
+
+                INPUT:
+
+                - ``numerical`` -- a boolean; whether to return the angle as a
+                  floating point number.
+
+                EXAMPLES::
+
+                    sage: from flatsurf import Polygon, similarity_surfaces
+                    sage: P = Polygon(vertices=[(0, 0), (2, 0), (1, 4), (0, 5)])
+                    sage: S = similarity_surfaces.self_glued_polygon(P)
+                    sage: S._angle_vertex(S(0, 0), numerical=False)
+                    1
+
+                """
+                turns, start, end = vertex.turns()
+
+                from flatsurf.geometry.euclidean import angle
+
+                return turns + angle(start, end, numerical=numerical)
+
+            @cached_surface_method
             def edge_matrix(self, p, e=None):
                 r"""
                 Returns the 2x2 matrix representing a similarity which when
@@ -2032,7 +2033,7 @@ class SimilaritySurfaces(SurfaceCategory):
 
                 return VectorSpace(self.base_ring(), 2)
 
-            @cached_method(key=lambda self, ring: ring or self.base_ring())
+            @cached_surface_method(key=lambda self, ring: ring or self.base_ring())
             def tangent_bundle(self, ring=None):
                 r"""
                 Return the tangent bundle

--- a/flatsurf/geometry/categories/similarity_surfaces.py
+++ b/flatsurf/geometry/categories/similarity_surfaces.py
@@ -119,8 +119,9 @@ from flatsurf.geometry.categories.surface_category import (
     SurfaceCategory,
     SurfaceCategoryWithAxiom,
 )
-from sage.categories.category_with_axiom import all_axioms
 from flatsurf.cache import cached_surface_method
+
+from sage.categories.category_with_axiom import all_axioms
 from sage.misc.cachefunc import cached_method
 from sage.all import QQ, AA
 

--- a/flatsurf/geometry/half_dilation_surface.py
+++ b/flatsurf/geometry/half_dilation_surface.py
@@ -21,8 +21,7 @@
 
 from flatsurf.geometry.surface import OrientedSimilaritySurface
 from flatsurf.geometry.mappings import SurfaceMapping
-
-from sage.misc.cachefunc import cached_method
+from flatsurf.cache import cached_surface_method
 
 
 class GL2RImageSurface(OrientedSimilaritySurface):
@@ -174,7 +173,7 @@ class GL2RImageSurface(OrientedSimilaritySurface):
         """
         return self._s.is_translation_surface(positive=positive)
 
-    @cached_method
+    @cached_surface_method
     def polygon(self, lab):
         r"""
         Return the polygon with ``label``.


### PR DESCRIPTION
we must not cache anything for surfaces that are mutable. However, once a surface becomes immutable, we enable caching which is as fast as SageMath's native cached method.

We checked with %timeit that this approach does the trick.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check. Remove checks that are not relevant and let us know if you need help with any of these.
-->
Checklist
* [x] Added an entry in `doc/news/`. <!-- Copy the TEMPLATE.rst to mybranch.rst, fill in the relevant sections, delete the others. -->
* [x] Added a test for this change.
* [x] Added new .py files to the documentation in `doc/geometry` or `doc/graphical`.

<!--
Please add any other relevant info below:
-->
