### PR TITLE
Fix Windows installer

### DIFF
--- a/doc/news/noble-move.rst
+++ b/doc/news/noble-move.rst
@@ -1,0 +1,3 @@
+**Fixed:**
+
+* Fixed Windows installer to point to the new location for Ubuntu WSL images.

--- a/installer/win/preset.json
+++ b/installer/win/preset.json
@@ -1,5 +1,5 @@
 {
-    "installfile":"https://cloud-images.ubuntu.com/wsl/noble/current/ubuntu-noble-wsl-amd64-24.04lts.rootfs.tar.gz",
+    "installfile":"https://cloud-images.ubuntu.com/wsl/releases/noble/current/ubuntu-noble-wsl-amd64-24.04lts.rootfs.tar.gz",
     "WslVersion": 2
 
 }


### PR DESCRIPTION
Ubuntu somehow moved their WSL images. The old location still exists but is empty.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check. Remove checks that are not relevant and let us know if you need help with any of these.
-->
Checklist
* [x] Added an entry in `doc/news/`. <!-- Copy the TEMPLATE.rst to mybranch.rst, fill in the relevant sections, delete the others. -->
* [x] Added a test for this change. Unfortunately no. It's hard to test this I think. But I also have not really looked into scripting Windows.
* [x] Added new .py files to the documentation in `doc/geometry` or `doc/graphical`.

<!--
Please add any other relevant info below:
-->
