### PR TITLE
Fix moduli computation in example

### DIFF
--- a/doc/examples/apisa_wright.md
+++ b/doc/examples/apisa_wright.md
@@ -123,7 +123,7 @@ for i, dec in enumerate(O.decompositions(16, bfs=True)):  # optional: pyflatsurf
         # .area() as reported by libflatsurf is actually twice the area
         areas = [cyl.area() / 2 for cyl in dec.cylinders()]
         moduli = [
-            (v.x() * v.x() + v.y() * v.y()) / area for v, area in zip(holonomies, areas)
+            area / (v.x() * v.x() + v.y() * v.y()) for v, area in zip(holonomies, areas)
         ]
         u = dec.vertical().vertical()
         print("saddle connection number", i)


### PR DESCRIPTION
Fixes #235. https://arxiv.org/pdf/1411.1827 Definition 3.3 defines the moduli as h/c where c is the circumference so we want to follow that definition.

Note that we use that correct definition in gl2r_orbit_closure.py

```py
  width = self.V2._isomorphic_vector_space.base_ring()(
      self.V2.base_ring()(component.width())
  )
  height = self.V2._isomorphic_vector_space.base_ring()(
      self.V2.base_ring()(
          component.vertical().project(component.circumferenceHolonomy())
      )
  )
  module_fractions.append((width, height))
```

What's confusing is that "height" is the circumference here and width is what is called height in the article (in the article, the flow is to the right, for us the flow is usually north.)

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check. Remove checks that are not relevant and let us know if you need help with any of these.
-->
Checklist
* [x] Added an entry in `doc/news/`. I don't think this is newsworthy in any way. <!-- Copy the TEMPLATE.rst to mybranch.rst, fill in the relevant sections, delete the others. -->
* [x] Added a test for this change. No, nothing to test I think.
* [x] Added new .py files to the documentation in `doc/geometry` or `doc/graphical`. Nothing new.

<!--
Please add any other relevant info below:
-->
