### PR TITLE
Allow tangent vectors pointing backwards along edges in non-convex surfaces

### DIFF
--- a/doc/news/non-convex-tangent-vector.rst
+++ b/doc/news/non-convex-tangent-vector.rst
@@ -1,0 +1,3 @@
+**Fixed:**
+
+* Fixed creation of tangent vectors in non-convex surfaces.

--- a/flatsurf/geometry/categories/similarity_surfaces.py
+++ b/flatsurf/geometry/categories/similarity_surfaces.py
@@ -3109,6 +3109,27 @@ class SimilaritySurfaces(SurfaceCategory):
                     sage: len(S.saddle_connections(63**2, initial_label=0, initial_vertex=0))
                     19
 
+                Verify that #351 has been resolved::
+
+                    sage: from flatsurf import MutableOrientedSimilaritySurface, Polygon
+
+                    sage: K.<a> = NumberField(x^4 - 2*x^3 - 5*x^2 + 6*x - 1, embedding=.2)
+                    sage: a1 = vector(K, (2 * a^3 - 3 * a^2 - 10 * a + 3, 1 / 4))
+                    sage: a2 = vector(K, (4 / 3 * a^3 - 2 * a^2 - 26 / 3 * a + 8 / 3, -1 / 5))
+                    sage: b1 = vector(K, (0, 2 / 3 * a^3 - a^2 - 13 / 3 * a + 11 / 6))
+                    sage: b2 = vector(K, (-1 / 4, 2 / 3 * a^3 - a^2 - 13 / 3 * a + 5 / 3))
+                    sage: P = Polygon(edges=[a1, a2, b1, -a2, b2, -a1, -b2, -b1])
+                    sage: S = MutableOrientedSimilaritySurface(K)
+                    sage: S.add_polygon(P)
+                    sage: S.glue((0, 0), (0, 5))
+                    sage: S.glue((0, 1), (0, 3))
+                    sage: S.glue((0, 2), (0, 7))
+                    sage: S.glue((0, 4), (0, 6))
+                    sage: S.set_immutable()
+
+                    sage: len(S.saddle_connections(1))
+                    12
+
                 """
                 if squared_length_bound <= 0:
                     raise ValueError

--- a/flatsurf/geometry/tangent_bundle.py
+++ b/flatsurf/geometry/tangent_bundle.py
@@ -120,18 +120,14 @@ class SimilaritySurfaceTangentVector:
         elif pos.is_vertex():
             v = pos.get_vertex()
             p = self.surface().polygon(polygon_label)
-            # subsequent edge:
-            edge1 = p.edge(v)
-            # prior edge:
-            edge0 = p.edge((v - 1) % len(p.vertices()))
-            wp1 = ccw(edge1, vector)
-            wp0 = ccw(edge0, vector)
-            if wp1 < 0 or wp0 < 0:
+
+            from flatsurf.geometry.euclidean import is_between
+            if is_between(-p.edge(v - 1), p.edge(v), vector):
                 raise ValueError(
                     "Singular point with vector pointing away from polygon"
                 )
-            if wp0 == 0:
-                # vector points backward along edge 0
+            if is_anti_parallel(p.edge(v - 1), vector):
+                # vector points backward along previous edge
                 label2, e2 = self.surface().opposite_edge(
                     polygon_label, (v - 1) % len(p.vertices())
                 )
@@ -147,7 +143,7 @@ class SimilaritySurfaceTangentVector:
                     self.surface().polygon(label2).get_point_position(point2)
                 )
             else:
-                # vector points along edge1 in that directior or points into polygons interior
+                # vector points along subsequent edge or points into polygons interior
                 self._polygon_label = polygon_label
                 self._point = point
                 self._vector = vector
@@ -339,7 +335,6 @@ class SimilaritySurfaceTangentVector:
         """
         p = self.polygon()
         point2, pos2 = p.flow_to_exit(self.point(), self.vector())
-        # diff=point2-point
         new_vector = SimilaritySurfaceTangentVector(
             self.bundle(), self.polygon_label(), point2, -self.vector()
         )


### PR DESCRIPTION
fixes #351.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check. Remove checks that are not relevant and let us know if you need help with any of these.
-->
Checklist
* [x] Added an entry in `doc/news/`. <!-- Copy the TEMPLATE.rst to mybranch.rst, fill in the relevant sections, delete the others. -->
* [x] Added a test for this change.

Seems to work now:

Length 1 saddle connections:

<img width="461" height="458" alt="image" src="https://github.com/user-attachments/assets/9ac6fb8d-3484-4973-a869-ef20e1b193a6" />

And length 2:

<img width="463" height="455" alt="image" src="https://github.com/user-attachments/assets/12e68c05-dfb7-4748-83f9-2868377631fd" />

